### PR TITLE
Update README to include port information

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -10,6 +10,8 @@ The examples use `graphql-client-example-server`, install and run like this:
 npm install -g graphql-client-example-server && graphql-client-example-server
 ```
 
+You will now have a GraphQL server running at https://localhost:4000.
+
 ### Run client
 
-`yarn && yarn start` will install all dependencies and start BuckleScript, Webpack and the Relay compiler.
+`yarn && yarn start` will install all dependencies and start BuckleScript, Webpack and the Relay compiler. The app will now be available at https://localhost:9000.


### PR DESCRIPTION
When running the example for the first time, it wasn't super clear to me which port the app was running on without digging through the webpack config. This PR shows new users info in the README for when they first run the project.

If you know a quick way to show this clearly in console output, I think that would be better but I couldn't find an answer with a quick google so this appears an intermediate solution to me.