### PR TITLE
Update subscriptionFunction bindings

### DIFF
--- a/packages/reason-relay/__tests__/Test_subscription.re
+++ b/packages/reason-relay/__tests__/Test_subscription.re
@@ -111,7 +111,7 @@ let test_subscription = () => {
   let observable =
     ReasonRelay.Observable.make(sink => {theSink := Some(sink)});
 
-  let subscriptionFunction = _ => observable;
+  let subscriptionFunction = (_, _, _) => observable;
 
   let network =
     ReasonRelay.Network.makePromiseBased(

--- a/packages/reason-relay/src/ReasonRelay.re
+++ b/packages/reason-relay/src/ReasonRelay.re
@@ -388,13 +388,7 @@ module Network = {
     operationKind: string,
   };
 
-  type subscribeFnConfig = {
-    request: operation,
-    variables: Js.Json.t,
-    cacheConfig,
-  };
-
-  type subscribeFn = subscribeFnConfig => Observable.t;
+  type subscribeFn = (operation, Js.Json.t, cacheConfig) => Observable.t;
 
   type fetchFunctionPromise =
     (operation, Js.Json.t, cacheConfig) => Js.Promise.t(Js.Json.t);

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -313,13 +313,7 @@ module Network: {
     operationKind: string,
   };
 
-  type subscribeFnConfig = {
-    request: operation,
-    variables: Js.Json.t,
-    cacheConfig,
-  };
-
-  type subscribeFn = subscribeFnConfig => Observable.t;
+  type subscribeFn = (operation, Js.Json.t, cacheConfig) => Observable.t;
 
   type fetchFunctionPromise =
     (operation, Js.Json.t, cacheConfig) => Js.Promise.t(Js.Json.t);


### PR DESCRIPTION
Update bindings for `subscriptionFunction`

[Relay type](https://github.com/facebook/relay/blob/master/packages/relay-runtime/network/RelayNetworkTypes.js#L102)
```typescript
/**
 * A function that executes a GraphQL subscription operation, returning zero or
 * more raw server responses over time.
 */
export type SubscribeFunction = (
  request: RequestParameters,
  variables: Variables,
  cacheConfig: CacheConfig,
) => RelayObservable<GraphQLResponse>;
```