### PR TITLE
fix: commitMutation's response type isn't actually nullable in Relay

### DIFF
--- a/packages/reason-relay/__tests__/Test_mutation.re
+++ b/packages/reason-relay/__tests__/Test_mutation.re
@@ -126,7 +126,7 @@ module Test = {
           )
           ->Promise.get(
               fun
-              | Ok((Some(res), _)) => setMutationResult(_ => Some(res))
+              | Ok((res, _)) => setMutationResult(_ => Some(res))
               | _ => Js.log("oops!"),
             )
         }>

--- a/packages/reason-relay/src/ReasonRelay.re
+++ b/packages/reason-relay/src/ReasonRelay.re
@@ -1041,10 +1041,7 @@ type _commitMutationConfig('variables, 'response) = {
   mutation: mutationNode,
   variables: 'variables,
   onCompleted:
-    option(
-      (Js.Nullable.t('response), Js.Nullable.t(array(mutationError))) =>
-      unit,
-    ),
+    option(('response, Js.Nullable.t(array(mutationError))) => unit),
   onError: option(Js.Nullable.t(mutationError) => unit),
   optimisticResponse: option('response),
   optimisticUpdater: option(optimisticUpdaterFn),
@@ -1134,13 +1131,7 @@ module MakeCommitMutation = (C: MutationConfig) => {
             (res, err) =>
               switch (onCompleted) {
               | Some(cb) =>
-                cb(
-                  switch (Js.Nullable.toOption(res)) {
-                  | Some(res) => Some(res->C.convertResponse)
-                  | None => None
-                  },
-                  Js.Nullable.toOption(err),
-                )
+                cb(res->C.convertResponse, Js.Nullable.toOption(err))
               | None => ()
               },
           ),
@@ -1178,7 +1169,7 @@ module MakeCommitMutation = (C: MutationConfig) => {
       )
       : Promise.t(
           Belt.Result.t(
-            (option(C.response), option(array(mutationError))),
+            (C.response, option(array(mutationError))),
             option(mutationError),
           ),
         ) => {
@@ -1194,13 +1185,7 @@ module MakeCommitMutation = (C: MutationConfig) => {
             Some(
               (res, err) =>
                 resolve(
-                  Ok((
-                    switch (Js.Nullable.toOption(res)) {
-                    | Some(res) => Some(res->C.convertResponse)
-                    | None => None
-                    },
-                    Js.Nullable.toOption(err),
-                  )),
+                  Ok((res->C.convertResponse, Js.Nullable.toOption(err))),
                 ),
             ),
           onError: Some(err => resolve(Error(Js.Nullable.toOption(err)))),

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -701,9 +701,7 @@ module MakeCommitMutation:
         ~optimisticUpdater: optimisticUpdaterFn=?,
         ~optimisticResponse: C.response=?,
         ~updater: (RecordSourceSelectorProxy.t, C.response) => unit=?,
-        ~onCompleted: (option(C.response), option(array(mutationError))) =>
-                      unit
-                        =?,
+        ~onCompleted: (C.response, option(array(mutationError))) => unit=?,
         ~onError: option(mutationError) => unit=?,
         unit
       ) =>
@@ -720,7 +718,7 @@ module MakeCommitMutation:
       ) =>
       Promise.t(
         Belt.Result.t(
-          (option(C.response), option(array(mutationError))),
+          (C.response, option(array(mutationError))),
           option(mutationError),
         ),
       );


### PR DESCRIPTION
cc @renanmav 

Thanks for giving this a shot! I think what might've been confusing is that there was quite a few places where the `Js.Nullable` unwrapping needed to be removed. Plus the signature of `commitMutationPromised` needed to be changed too, which I didn't tell you 🙁Sorry!

Anyway, I think you got hit by a weird type inference thing (it telling you that `optimisticResponse` needed changing), which was probably caused by the fact that I didn't tell you to change the signature of `commitMutationPromised`.

Do these changes make sense to?