### PR TITLE
Update reason react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master
 
+- _BREAKING CHANGE_ Bindings in `ReactExperimental` for `Suspense`, `SuspenseList`, `ConcurrentModeRoot.render`, `createRoot` and `useTransition` have been moved to the official community bindings in [Reason-React](https://github.com/reasonml/reason-react).
+- Peer dependencies updated `reason-react@^0.8.0` and `bs-platform@^7.3.2`
+
 # 0.9.2
 
 - Automatic conversion of custom scalars! Heavily inspired by the upcoming `graphql_ppx` release which also has this, it's now possible to have ReasonRelay automatically convert your custom scalars at runtime. More info in the docs for custom scalars.

--- a/packages/reason-relay/__tests__/TestProviders.re
+++ b/packages/reason-relay/__tests__/TestProviders.re
@@ -1,10 +1,9 @@
 module Wrapper = {
   [@react.component]
   let make = (~environment, ~children) =>
-    <ReactExperimental.Suspense
-      fallback={<div> {React.string("Loading...")} </div>}>
+    <React.Suspense fallback={<div> {React.string("Loading...")} </div>}>
       <ReasonRelay.Context.Provider environment>
         children
       </ReasonRelay.Context.Provider>
-    </ReactExperimental.Suspense>;
+    </React.Suspense>;
 };

--- a/packages/reason-relay/__tests__/Test_pagination.re
+++ b/packages/reason-relay/__tests__/Test_pagination.re
@@ -83,7 +83,7 @@ module Test = {
     let query = Query.use(~variables={groupId: groupId}, ());
 
     let (startTransition, _) =
-      ReactExperimental.useTransition(~timeoutMs=5000, ());
+      React.useTransition(~config={timeoutMs: 500}, ());
 
     let ReasonRelay.{data, hasNext, loadNext, isLoadingNext, refetch} =
       Fragment.usePagination(query.getFragmentRefs());

--- a/packages/reason-relay/__tests__/Test_refetching.re
+++ b/packages/reason-relay/__tests__/Test_refetching.re
@@ -34,7 +34,7 @@ module Test = {
       Fragment.useRefetchable(query.loggedInUser.getFragmentRefs());
 
     let (startTransition, _) =
-      ReactExperimental.useTransition(~timeoutMs=5000, ());
+      React.useTransition(~config={timeoutMs: 5000}, ());
 
     <div>
       {React.string(

--- a/packages/reason-relay/package.json
+++ b/packages/reason-relay/package.json
@@ -40,7 +40,7 @@
     "react": "0.0.0-experimental-d28bd2994",
     "react-dom": "0.0.0-experimental-d28bd2994",
     "react-relay": "0.0.0-experimental-8cc94ddc",
-    "reason-react": "^0.7.0",
+    "reason-react": "^0.8.0",
     "relay-compiler": "9.0.0",
     "relay-config": "9.0.0",
     "relay-runtime": "9.0.0",

--- a/packages/reason-relay/package.json
+++ b/packages/reason-relay/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",
     "bs-fetch": "^0.5.0",
-    "bs-platform": "^7.1.1",
+    "bs-platform": "^7.3.2",
     "graphql": "14.5.0",
     "graphql-query-test-mock": "^0.12.1",
     "jest": "^24.9.0",

--- a/packages/reason-relay/package.json
+++ b/packages/reason-relay/package.json
@@ -47,12 +47,12 @@
     "reason-promise": "^1.0.2"
   },
   "peerDependencies": {
-    "bs-platform": "^7.1.1",
+    "bs-platform": "^7.3.2",
     "graphql": "^14.4.2",
     "react": "0.0.0-experimental-d28bd2994",
     "react-dom": "0.0.0-experimental-d28bd2994",
     "react-relay": "0.0.0-experimental-8cc94ddc",
-    "reason-react": "^0.7.0",
+    "reason-react": "^0.8.0",
     "relay-compiler": "9.0.0",
     "relay-config": "9.0.0",
     "relay-runtime": "9.0.0",

--- a/packages/reason-relay/src/ReactExperimental.re
+++ b/packages/reason-relay/src/ReactExperimental.re
@@ -12,12 +12,6 @@ let useDeferredValue =
     (~value, ~timeoutMs, ~busyDelayMs=?, ~busyMinDurationMs=?, ()) =>
   _useDeferredValue(value, {timeoutMs, busyDelayMs, busyMinDurationMs});
 
-let renderConcurrentRootAtElementWithId = (reactElement, id) =>
-  switch (ReactDOMRe.Experimental.createRootWithId(id)) {
-  | Error(error) => raise(Invalid_argument(error))
-  | Ok(root) => ReactDOMRe.Experimental.render(root, reactElement)
-  };
-
 [@bs.module "react"]
 external unstable_withSuspenseConfig: (unit => unit, suspenseConfig) => unit =
   "unstable_withSuspenseConfig";

--- a/packages/reason-relay/src/ReactExperimental.re
+++ b/packages/reason-relay/src/ReactExperimental.re
@@ -19,30 +19,10 @@ let useDeferredValue =
     (~value, ~timeoutMs, ~busyDelayMs=?, ~busyMinDurationMs=?, ()) =>
   _useDeferredValue(value, {timeoutMs, busyDelayMs, busyMinDurationMs});
 
-[@bs.val] [@bs.return nullable]
-external _getElementById: string => option(Dom.element) =
-  "document.getElementById";
-
-module ConcurrentModeRoot = {
-  type t = {. "render": [@bs.meth] (React.element => unit)};
-  let render = (t: t, element) => t##render(element);
-};
-
-[@bs.module "react-dom"]
-external createRoot: Dom.element => ConcurrentModeRoot.t = "createRoot";
-
 let renderConcurrentRootAtElementWithId = (reactElement, id) =>
-  switch (_getElementById(id)) {
-  | None =>
-    raise(
-      Invalid_argument(
-        "ReactExperimental.createRootAtElementWithId : no element of id "
-        ++ id
-        ++ " found in the HTML.",
-      ),
-    )
-  | Some(element) =>
-    createRoot(element)->ConcurrentModeRoot.render(reactElement)
+  switch (ReactDOMRe.Experimental.createRootWithId(id)) {
+  | Error(error) => raise(Invalid_argument(error))
+  | Ok(root) => ReactDOMRe.Experimental.render(root, reactElement)
   };
 
 [@bs.module "react"]

--- a/packages/reason-relay/src/ReactExperimental.re
+++ b/packages/reason-relay/src/ReactExperimental.re
@@ -45,38 +45,6 @@ let renderConcurrentRootAtElementWithId = (reactElement, id) =>
     createRoot(element)->ConcurrentModeRoot.render(reactElement)
   };
 
-module Suspense = {
-  [@react.component] [@bs.module "react"]
-  external make:
-    (~children: React.element, ~fallback: ReasonReact.reactElement=?) =>
-    React.element =
-    "Suspense";
-};
-
-module SuspenseList = {
-  type revealOrder = [ | `forwards | `backwards | `together];
-
-  module Component = {
-    [@react.component] [@bs.module "react"]
-    external make:
-      (~children: React.element, ~revealOrder: string) => React.element =
-      "SuspenseList";
-  };
-
-  let mapRevealOrder = revealOrder =>
-    switch (revealOrder) {
-    | `forwards => "forwards"
-    | `backwards => "backwards"
-    | `together => "together"
-    };
-
-  [@react.component]
-  let make = (~children, ~revealOrder: revealOrder) =>
-    <Component revealOrder={revealOrder |> mapRevealOrder}>
-      children
-    </Component>;
-};
-
 [@bs.module "react"]
 external unstable_withSuspenseConfig: (unit => unit, suspenseConfig) => unit =
   "unstable_withSuspenseConfig";

--- a/packages/reason-relay/src/ReactExperimental.re
+++ b/packages/reason-relay/src/ReactExperimental.re
@@ -5,13 +5,6 @@ type suspenseConfig = {
 };
 
 [@bs.module "react"]
-external _useTransition: suspenseConfig => ((unit => unit) => unit, bool) =
-  "useTransition";
-
-let useTransition = (~timeoutMs, ~busyDelayMs=?, ~busyMinDurationMs=?, ()) =>
-  _useTransition({timeoutMs, busyDelayMs, busyMinDurationMs});
-
-[@bs.module "react"]
 external _useDeferredValue: ('value, suspenseConfig) => 'value =
   "useDeferredValue";
 

--- a/packages/reason-relay/src/ReactExperimental.rei
+++ b/packages/reason-relay/src/ReactExperimental.rei
@@ -14,7 +14,4 @@ let useDeferredValue:
   ) =>
   'value;
 
-let renderConcurrentRootAtElementWithId:
-  (ReasonReact.reactElement, string) => unit;
-
 let unstable_withSuspenseConfig: (unit => unit, suspenseConfig) => unit;

--- a/packages/reason-relay/src/ReactExperimental.rei
+++ b/packages/reason-relay/src/ReactExperimental.rei
@@ -4,10 +4,6 @@ type suspenseConfig = {
   busyMinDurationMs: option(int),
 };
 
-let useTransition:
-  (~timeoutMs: int, ~busyDelayMs: int=?, ~busyMinDurationMs: int=?, unit) =>
-  ((unit => unit) => unit, bool);
-
 let useDeferredValue:
   (
     ~value: 'value,

--- a/packages/reason-relay/src/ReactExperimental.rei
+++ b/packages/reason-relay/src/ReactExperimental.rei
@@ -18,13 +18,6 @@ let useDeferredValue:
   ) =>
   'value;
 
-module ConcurrentModeRoot: {
-  type t;
-  let render: (t, ReasonReact.reactElement) => unit;
-};
-
-let createRoot: Dom.element => ConcurrentModeRoot.t;
-
 let renderConcurrentRootAtElementWithId:
   (ReasonReact.reactElement, string) => unit;
 

--- a/packages/reason-relay/src/ReactExperimental.rei
+++ b/packages/reason-relay/src/ReactExperimental.rei
@@ -28,23 +28,4 @@ let createRoot: Dom.element => ConcurrentModeRoot.t;
 let renderConcurrentRootAtElementWithId:
   (ReasonReact.reactElement, string) => unit;
 
-module Suspense: {
-  [@react.component]
-  let make:
-    (
-      ~children: ReasonReact.reactElement,
-      ~fallback: ReasonReact.reactElement=?
-    ) =>
-    ReasonReact.reactElement;
-};
-
-module SuspenseList: {
-  type revealOrder = [ | `forwards | `backwards | `together];
-
-  [@react.component]
-  let make:
-    (~children: ReasonReact.reactElement, ~revealOrder: revealOrder) =>
-    ReasonReact.reactElement;
-};
-
 let unstable_withSuspenseConfig: (unit => unit, suspenseConfig) => unit;

--- a/packages/reason-relay/yarn.lock
+++ b/packages/reason-relay/yarn.lock
@@ -1077,10 +1077,10 @@ bs-fetch@^0.5.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.5.0.tgz#6913b1d1ddfa0b0a4b832357854e9763d61d4b28"
   integrity sha512-cGjwRpyNcIaX+p2ssy/38zs7BM/miKNgmOR3NEhxKFete5mR05JcvjuV4raG89oGCG281SU1b56TTAKmf9VCug==
 
-bs-platform@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.1.1.tgz#ed4032de7ab15158c61d8994680a05393e3ddd74"
-  integrity sha512-ckZHR3J+yxyEKXOBHX8+hfzWG2XX5BxhQ4Iw9lulHFGYdAm9Ep9LgKkIah7G6RYADLmVfTxFE48igvY3kkkl+g==
+bs-platform@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.3.2.tgz#301f5c9b4e8cf5713cb60ca22e145e56e793affe"
+  integrity sha512-seJL5g4anK9la4erv+B2o2sMHQCxDF6OCRl9en3hbaUos/S3JsusQ0sPp4ORsbx5eXfHLYBwPljwKXlgpXtsgQ==
 
 bser@2.1.1:
   version "2.1.1"

--- a/packages/reason-relay/yarn.lock
+++ b/packages/reason-relay/yarn.lock
@@ -3359,16 +3359,6 @@ react-dom@0.0.0-experimental-d28bd2994:
     prop-types "^15.6.2"
     scheduler "0.0.0-experimental-d28bd2994"
 
-react-dom@>=16.8.1:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
-  integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.18.0"
-
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -3388,15 +3378,6 @@ react@0.0.0-experimental-d28bd2994:
   version "0.0.0-experimental-d28bd2994"
   resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-d28bd2994.tgz#1fe415fa636e361a0370aa0b5d81db5a3200d9f4"
   integrity sha512-5JUhJHB42Rz9SCDiPC++cm6hUErdcNPynlZWNZYB/Hi7rN0SPDIzHrZzRZPc+VaJ9gEdUVdlfbeZC5aTEIT90Q==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@>=16.8.1:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
-  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -3431,13 +3412,10 @@ reason-promise@^1.0.2:
   resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
   integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
-reason-react@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
-  integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
-  dependencies:
-    react ">=16.8.1"
-    react-dom ">=16.8.1"
+reason-react@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.8.0.tgz#a55143f95a872596c92b54595e7904c03ee7c9db"
+  integrity sha512-97AfK3eCF6vfP8rnbq3k6GgXsZt//OiPMINTUk5luJ8W0Wt/JaYsDG6eWKP8Zx3gPpxSU1EPjB1pUm6o6fBnFA==
 
 reason@^3.3.4:
   version "3.3.4"
@@ -3669,14 +3647,6 @@ scheduler@0.0.0-experimental-d28bd2994:
   version "0.0.0-experimental-d28bd2994"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-d28bd2994.tgz#5da5de2d3bd037b469ac228bce1084eed7b6810b"
   integrity sha512-OhxZYPVBmKZu9J3c5dH8M9f0hetdXjC8ElEQBHojRoH1FRiHWMf0Uw2HG8xFV992vcBKvx8rGQha4nKPTPVdFw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
-  integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
### What
- Update `bs-platform` and  `reason-react`
- Remove bindings that are now in `reason-react`
- Remove helper function `renderConcurrentRootAtElementWithId`

### Why
- Getting closer to not have to depend on specific react version.
- Use official community bindings for  `Suspense` 

