### PR TITLE
Rename generated getConnectionNodes function

### DIFF
--- a/packages/reason-relay/__tests__/Test_paginationInNode.re
+++ b/packages/reason-relay/__tests__/Test_paginationInNode.re
@@ -76,7 +76,7 @@ module UserNodeDisplayer = {
 
     <div>
       {data.friendsConnection
-       ->Fragment.getConnectionNodes_friendsConnection
+       ->Fragment.getConnectionNodes
        ->Belt.Array.map(user =>
            <div key={user.id}>
              <UserDisplayer user={user.fragmentRefs} />

--- a/packages/reason-relay/__tests__/Test_paginationUnion.re
+++ b/packages/reason-relay/__tests__/Test_paginationUnion.re
@@ -90,11 +90,11 @@ module Test = {
 
     <div>
       {data.members
-       ->Fragment.getConnectionNodes_members
+       ->Fragment.getConnectionNodes
        ->Belt.Array.mapWithIndex((i, member) =>
            switch (member) {
            | `User(user) =>
-             <div id={user.id}>
+             <div key={user.id}>
                <UserDisplayer user={user.fragmentRefs} />
              </div>
            | `Group(group) =>

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
@@ -41,7 +41,7 @@ external getFragmentRef:
 
 module Utils = {
   open Types;
-  let getConnectionNodes_friendsConnection:
+  let getConnectionNodes:
     fragment_friendsConnection => array(fragment_friendsConnection_edges_node) =
     connection =>
       switch (connection.edges) {

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.re
@@ -99,7 +99,7 @@ external getFragmentRef:
 
 module Utils = {
   open Types;
-  let getConnectionNodes_members:
+  let getConnectionNodes:
     option(fragment_members) => array(fragment_members_edges_node) =
     connection =>
       switch (connection) {

--- a/packages/reason-relay/language-plugin/src/generator/UtilsPrinter.re
+++ b/packages/reason-relay/language-plugin/src/generator/UtilsPrinter.re
@@ -52,7 +52,7 @@ let printConnectionTraverser =
 
 let printFullGetConnectionNodesFnDefinition =
     (
-      ~connectionLocation,
+      ~functionName,
       ~connectionPropNullable,
       ~connectionTypeName,
       ~nodeTypeName,
@@ -60,8 +60,8 @@ let printFullGetConnectionNodesFnDefinition =
       ~edgesNullable,
       ~nodeNullable,
     ) =>
-  "let getConnectionNodes_"
-  ++ connectionLocation
+  "let "
+  ++ functionName
   ++ ": "
   ++ (connectionPropNullable ? "option(" : "")
   ++ connectionTypeName
@@ -78,7 +78,13 @@ let printFullGetConnectionNodesFnDefinition =
   ++ ";";
 
 let printGetConnectionNodesFunction =
-    (~state: fullState, ~connectionLocation: string, obj: object_): string => {
+    (
+      ~functionName,
+      ~state: fullState,
+      ~connectionLocation: string,
+      obj: object_,
+    )
+    : string => {
   let str = ref("");
   let addToStr = s => str := str^ ++ s;
 
@@ -144,7 +150,7 @@ let printGetConnectionNodesFunction =
                          ) =>
                          addToStr(
                            printFullGetConnectionNodesFnDefinition(
-                             ~connectionLocation,
+                             ~functionName,
                              ~connectionPropNullable,
                              ~connectionTypeName,
                              ~nodeTypeName,
@@ -160,7 +166,7 @@ let printGetConnectionNodesFunction =
                          ) =>
                          addToStr(
                            printFullGetConnectionNodesFnDefinition(
-                             ~connectionLocation,
+                             ~functionName,
                              ~connectionPropNullable,
                              ~connectionTypeName,
                              ~nodeTypeName=

--- a/packages/reason-relay/language-plugin/src/transformer/TypesTransformer.re
+++ b/packages/reason-relay/language-plugin/src/transformer/TypesTransformer.re
@@ -464,6 +464,7 @@ let getPrintedFullState =
     | (Some(obj), _) =>
       obj.definition
       |> UtilsPrinter.printGetConnectionNodesFunction(
+           ~functionName="getConnectionNodes",
            ~state,
            ~connectionLocation=connection.fieldName,
          )
@@ -474,6 +475,7 @@ let getPrintedFullState =
         when connPath == ["fragment"] =>
       definition
       |> UtilsPrinter.printGetConnectionNodesFunction(
+           ~functionName="getConnectionNodes",
            ~state,
            ~connectionLocation=connection.fieldName,
          )


### PR DESCRIPTION
Relay only allows one `@connection` per operation/fragment - no need to generate a unique name for `getConnetionNodes`.