### PR TITLE
Bindings cleanup v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 
 - _BREAKING CHANGE_ replace unsetValue with setValueToUndefined and setValueToNull
+- clean bindings, renamed internal raw types and functions with names ending with `Raw`, 
+use abstract records instead of Js.t objects for a more robust type-check and to avoid undefined fields
 
 # 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master
 
+
+- _BREAKING CHANGE_ replace unsetValue with setValueToUndefined and setValueToNull
+
 # 0.11.0
 
 Another release, primarily to enable zero cost enums via `bs-platform` `8.2.0`. No new Relay version, and hopefully a managable amount of breaking changes.

--- a/packages/reason-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.re
@@ -55,7 +55,7 @@ module Internal = {
   };
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -72,7 +72,7 @@ module Internal = {
   };
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestFragmentQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestFragmentQuery_graphql.re
@@ -31,7 +31,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -46,7 +46,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestFragment_plural_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestFragment_plural_user_graphql.re
@@ -21,7 +21,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestFragment_sub_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestFragment_sub_user_graphql.re
@@ -14,7 +14,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestFragment_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestFragment_user_graphql.re
@@ -20,7 +20,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersMeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersMeQuery_graphql.re
@@ -17,7 +17,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -32,7 +32,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersQuery_graphql.re
@@ -20,7 +20,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -35,7 +35,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMutationQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationQuery_graphql.re
@@ -19,7 +19,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -34,7 +34,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.re
@@ -28,7 +28,7 @@ module Internal = {
   let wrapResponseConverterMap = ();
   let convertWrapResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         wrapResponseConverter,
         wrapResponseConverterMap,
         Js.null,
@@ -41,7 +41,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -59,7 +59,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.re
@@ -34,7 +34,7 @@ module Internal = {
   let wrapResponseConverterMap = ();
   let convertWrapResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         wrapResponseConverter,
         wrapResponseConverterMap,
         Js.null,
@@ -47,7 +47,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -60,7 +60,7 @@ module Internal = {
   let wrapRawResponseConverterMap = ();
   let convertWrapRawResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         wrapRawResponseConverter,
         wrapRawResponseConverterMap,
         Js.null,
@@ -73,7 +73,7 @@ module Internal = {
   let rawResponseConverterMap = ();
   let convertRawResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         rawResponseConverter,
         rawResponseConverterMap,
         Js.undefined,
@@ -85,7 +85,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.re
@@ -31,7 +31,7 @@ module Internal = {
   let wrapResponseConverterMap = ();
   let convertWrapResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         wrapResponseConverter,
         wrapResponseConverterMap,
         Js.null,
@@ -44,7 +44,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -57,7 +57,7 @@ module Internal = {
   let wrapRawResponseConverterMap = ();
   let convertWrapRawResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         wrapRawResponseConverter,
         wrapRawResponseConverterMap,
         Js.null,
@@ -70,7 +70,7 @@ module Internal = {
   let rawResponseConverterMap = ();
   let convertRawResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         rawResponseConverter,
         rawResponseConverterMap,
         Js.undefined,
@@ -82,7 +82,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestMutation_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutation_user_graphql.re
@@ -21,7 +21,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestNodeInterfaceQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestNodeInterfaceQuery_graphql.re
@@ -20,7 +20,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -35,7 +35,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.re
@@ -25,7 +25,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -40,7 +40,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
@@ -39,7 +39,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -54,7 +54,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
@@ -11,22 +11,22 @@ module Types = {
   type response = {node: option(response_node)};
   type rawResponse = response;
   type refetchVariables = {
+    onlineStatuses: option(array(enum_OnlineStatus)),
     count: option(int),
     cursor: option(string),
-    onlineStatuses: option(array(enum_OnlineStatus)),
     id: option(string),
   };
   let makeRefetchVariables =
-      (~count=?, ~cursor=?, ~onlineStatuses=?, ~id=?, ()): refetchVariables => {
+      (~onlineStatuses=?, ~count=?, ~cursor=?, ~id=?, ()): refetchVariables => {
+    onlineStatuses,
     count,
     cursor,
-    onlineStatuses,
     id,
   };
   type variables = {
+    onlineStatuses: option(array(enum_OnlineStatus)),
     count: option(int),
     cursor: option(string),
-    onlineStatuses: option(array(enum_OnlineStatus)),
     id: string,
   };
 };
@@ -49,7 +49,7 @@ module Internal = {
   let convertRawResponse = convertResponse;
 
   let variablesConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"count":{"n":""},"cursor":{"n":""},"onlineStatuses":{"n":""}}} |json}
+    {json| {"__root":{"onlineStatuses":{"n":""},"count":{"n":""},"cursor":{"n":""}}} |json}
   ];
   let variablesConverterMap = ();
   let convertVariables = v =>
@@ -67,10 +67,10 @@ module Utils = {
   external onlineStatus_toString: enum_OnlineStatus => string = "%identity";
   open Types;
   let makeVariables =
-      (~count=?, ~cursor=?, ~onlineStatuses=?, ~id, ()): variables => {
+      (~onlineStatuses=?, ~count=?, ~cursor=?, ~id, ()): variables => {
+    onlineStatuses,
     count,
     cursor,
-    onlineStatuses,
     id,
   };
 };

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
@@ -27,7 +27,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
@@ -15,14 +15,14 @@ module Types = {
 
   type fragment = {
     friendsConnection: fragment_friendsConnection,
-    id: string,
+    id: option(string),
   };
 };
 
 module Internal = {
   type fragmentRaw;
   let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"friendsConnection_edges":{"n":"","na":""},"friendsConnection_edges_node":{"n":"","f":""}}} |json}
+    {json| {"__root":{"friendsConnection_edges":{"n":"","na":""},"friendsConnection_edges_node":{"n":"","f":""},"id":{"n":""}}} |json}
   ];
   let fragmentConverterMap = ();
   let convertFragment = v =>

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_user_graphql.re
@@ -19,7 +19,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.re
@@ -22,7 +22,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -37,7 +37,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
@@ -39,7 +39,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -54,7 +54,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
@@ -10,24 +10,24 @@ module Types = {
   };
   type rawResponse = response;
   type refetchVariables = {
-    count: option(int),
-    cursor: option(string),
     groupId: option(string),
     onlineStatuses: option(array(enum_OnlineStatus)),
-  };
-  let makeRefetchVariables =
-      (~count=?, ~cursor=?, ~groupId=?, ~onlineStatuses=?, ())
-      : refetchVariables => {
-    count,
-    cursor,
-    groupId,
-    onlineStatuses,
-  };
-  type variables = {
     count: option(int),
     cursor: option(string),
+  };
+  let makeRefetchVariables =
+      (~groupId=?, ~onlineStatuses=?, ~count=?, ~cursor=?, ())
+      : refetchVariables => {
+    groupId,
+    onlineStatuses,
+    count,
+    cursor,
+  };
+  type variables = {
     groupId: string,
     onlineStatuses: option(array(enum_OnlineStatus)),
+    count: option(int),
+    cursor: option(string),
   };
 };
 
@@ -49,7 +49,7 @@ module Internal = {
   let convertRawResponse = convertResponse;
 
   let variablesConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"count":{"n":""},"cursor":{"n":""},"onlineStatuses":{"n":""}}} |json}
+    {json| {"__root":{"onlineStatuses":{"n":""},"count":{"n":""},"cursor":{"n":""}}} |json}
   ];
   let variablesConverterMap = ();
   let convertVariables = v =>
@@ -67,11 +67,11 @@ module Utils = {
   external onlineStatus_toString: enum_OnlineStatus => string = "%identity";
   open Types;
   let makeVariables =
-      (~count=?, ~cursor=?, ~groupId, ~onlineStatuses=?, ()): variables => {
-    count,
-    cursor,
+      (~groupId, ~onlineStatuses=?, ~count=?, ~cursor=?, ()): variables => {
     groupId,
     onlineStatuses,
+    count,
+    cursor,
   };
 };
 

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.re
@@ -85,7 +85,7 @@ module Internal = {
   };
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnion_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnion_user_graphql.re
@@ -18,7 +18,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestQuery_graphql.re
@@ -31,7 +31,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -46,7 +46,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.re
@@ -24,7 +24,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -39,7 +39,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
@@ -37,7 +37,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -52,7 +52,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
@@ -11,20 +11,20 @@ module Types = {
   type response = {node: option(response_node)};
   type rawResponse = response;
   type refetchVariables = {
-    friendsOnlineStatuses: option(array(enum_OnlineStatus)),
     showOnlineStatus: option(bool),
+    friendsOnlineStatuses: option(array(enum_OnlineStatus)),
     id: option(string),
   };
   let makeRefetchVariables =
-      (~friendsOnlineStatuses=?, ~showOnlineStatus=?, ~id=?, ())
+      (~showOnlineStatus=?, ~friendsOnlineStatuses=?, ~id=?, ())
       : refetchVariables => {
-    friendsOnlineStatuses,
     showOnlineStatus,
+    friendsOnlineStatuses,
     id,
   };
   type variables = {
-    friendsOnlineStatuses: array(enum_OnlineStatus),
     showOnlineStatus: bool,
+    friendsOnlineStatuses: array(enum_OnlineStatus),
     id: string,
   };
 };
@@ -65,9 +65,9 @@ module Utils = {
   external onlineStatus_toString: enum_OnlineStatus => string = "%identity";
   open Types;
   let makeVariables =
-      (~friendsOnlineStatuses, ~showOnlineStatus, ~id): variables => {
-    friendsOnlineStatuses,
+      (~showOnlineStatus, ~friendsOnlineStatuses, ~id): variables => {
     showOnlineStatus,
+    friendsOnlineStatuses,
     id,
   };
 };

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.re
@@ -22,7 +22,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.re
@@ -10,14 +10,14 @@ module Types = {
     firstName: string,
     onlineStatus: option(enum_OnlineStatus),
     friendsConnection: fragment_friendsConnection,
-    id: string,
+    id: option(string),
   };
 };
 
 module Internal = {
   type fragmentRaw;
   let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"onlineStatus":{"n":""}}} |json}
+    {json| {"__root":{"onlineStatus":{"n":""},"id":{"n":""}}} |json}
   ];
   let fragmentConverterMap = ();
   let convertFragment = v =>

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingQuery_graphql.re
@@ -19,7 +19,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -34,7 +34,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.re
@@ -37,7 +37,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -52,7 +52,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetching_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetching_user_graphql.re
@@ -22,7 +22,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestRefetching_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetching_user_graphql.re
@@ -10,14 +10,14 @@ module Types = {
     firstName: string,
     onlineStatus: option(enum_OnlineStatus),
     friendsConnection: fragment_friendsConnection,
-    id: string,
+    id: option(string),
   };
 };
 
 module Internal = {
   type fragmentRaw;
   let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"onlineStatus":{"n":""}}} |json}
+    {json| {"__root":{"onlineStatus":{"n":""},"id":{"n":""}}} |json}
   ];
   let fragmentConverterMap = ();
   let convertFragment = v =>

--- a/packages/reason-relay/__tests__/__generated__/TestSubscriptionQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestSubscriptionQuery_graphql.re
@@ -19,7 +19,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -34,7 +34,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.re
@@ -24,7 +24,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -39,7 +39,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestSubscription_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestSubscription_user_graphql.re
@@ -21,7 +21,7 @@ module Internal = {
   let fragmentConverterMap = ();
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestUnionFragmentQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestUnionFragmentQuery_graphql.re
@@ -23,7 +23,7 @@ module Internal = {
   let responseConverterMap = ();
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -38,7 +38,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestUnionFragment_member_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestUnionFragment_member_graphql.re
@@ -51,7 +51,7 @@ module Internal = {
   let fragmentConverterMap = {"fragment": unwrap_fragment};
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.re
@@ -52,7 +52,7 @@ module Internal = {
   let fragmentConverterMap = {"fragment": unwrap_fragment};
   let convertFragment = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         fragmentConverter,
         fragmentConverterMap,
         Js.undefined,

--- a/packages/reason-relay/__tests__/__generated__/TestUnionsQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestUnionsQuery_graphql.re
@@ -128,7 +128,7 @@ module Internal = {
   };
   let convertResponse = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         responseConverter,
         responseConverterMap,
         Js.undefined,
@@ -143,7 +143,7 @@ module Internal = {
   let variablesConverterMap = ();
   let convertVariables = v =>
     v
-    ->ReasonRelay._convertObj(
+    ->ReasonRelay.convertObj(
         variablesConverter,
         variablesConverterMap,
         Js.undefined,

--- a/packages/reason-relay/language-plugin/src/transformer/TypesTransformerUtils.re
+++ b/packages/reason-relay/language-plugin/src/transformer/TypesTransformerUtils.re
@@ -33,7 +33,7 @@ let printConverterAssets =
   ++ assets.convertersDefinition
   ++ "let convert"
   ++ Tablecloth.String.capitalize(name)
-  ++ " = v => v->ReasonRelay._convertObj("
+  ++ " = v => v->ReasonRelay.convertObj("
   ++ name
   ++ "Converter, "
   ++ name

--- a/packages/reason-relay/src/ReasonRelay.re
+++ b/packages/reason-relay/src/ReasonRelay.re
@@ -94,10 +94,6 @@ let optArrayOfNullableToOptArrayOfOpt:
 module RecordProxy = {
   type t;
 
-  type unsetValueType =
-    | Null
-    | Undefined;
-
   [@bs.send]
   external copyFieldsFrom: (t, ~sourceRecord: t) => unit = "copyFieldsFrom";
 
@@ -172,13 +168,28 @@ module RecordProxy = {
     "setLinkedRecord";
 
   [@bs.send]
-  external unsetLinkedRecord: (t, 'nullable, string, option(arguments)) => t =
+  external setLinkedRecordToUndefined:
+    (
+      t,
+      [@bs.as {json|undefined|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
     "setLinkedRecord";
-  let unsetLinkedRecord = (t, ~name, ~unsetValue, ~arguments=?, ()) =>
-    switch (unsetValue) {
-    | Null => unsetLinkedRecord(t, Js.null, name, arguments)
-    | Undefined => unsetLinkedRecord(t, Js.undefined, name, arguments)
-    };
+
+  [@bs.send]
+  external setLinkedRecordToNull:
+    (
+      t,
+      [@bs.as {json|null|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
+    "setLinkedRecord";
 
   [@bs.send]
   external setLinkedRecords:
@@ -193,22 +204,52 @@ module RecordProxy = {
     "setLinkedRecords";
 
   [@bs.send]
-  external unsetLinkedRecords: (t, 'nullable, string, option(arguments)) => t =
+  external setLinkedRecordsToUndefined:
+    (
+      t,
+      [@bs.as {json|undefined|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
     "setLinkedRecords";
-  let unsetLinkedRecords = (t, ~name, ~unsetValue, ~arguments=?, ()) =>
-    switch (unsetValue) {
-    | Null => unsetLinkedRecords(t, Js.null, name, arguments)
-    | Undefined => unsetLinkedRecords(t, Js.undefined, name, arguments)
-    };
 
   [@bs.send]
-  external unsetValue_: (t, 'nullable, string, option(arguments)) => t =
+  external setLinkedRecordsToNull:
+    (
+      t,
+      [@bs.as {json|null|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
+    "setLinkedRecords";
+
+  [@bs.send]
+  external setValueToUndefined:
+    (
+      t,
+      [@bs.as {json|undefined|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
     "setValue";
-  let unsetValue = (t, ~name, ~unsetValue, ~arguments=?, ()) =>
-    switch (unsetValue) {
-    | Null => unsetValue_(t, Js.null, name, arguments)
-    | Undefined => unsetValue_(t, Js.undefined, name, arguments)
-    };
+
+  [@bs.send]
+  external setValueToNull:
+    (
+      t,
+      [@bs.as {json|null|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
+    "setValue";
 
   [@bs.send]
   external setValueString:

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -91,10 +91,6 @@ let _convertObj:
 module RecordProxy: {
   type t;
 
-  type unsetValueType =
-    | Null
-    | Undefined;
-
   [@bs.send]
   external copyFieldsFrom: (t, ~sourceRecord: t) => unit = "copyFieldsFrom";
 
@@ -218,35 +214,77 @@ module RecordProxy: {
     t =
     "setValue";
 
-  let unsetValue:
+  [@bs.send]
+  external setValueToUndefined:
     (
       t,
+      [@bs.as {json|undefined|json}] _,
       ~name: string,
-      ~unsetValue: unsetValueType,
       ~arguments: arguments=?,
       unit
     ) =>
-    t;
+    t =
+    "setValue";
 
-  let unsetLinkedRecord:
+  [@bs.send]
+  external setValueToNull:
     (
       t,
+      [@bs.as {json|null|json}] _,
       ~name: string,
-      ~unsetValue: unsetValueType,
       ~arguments: arguments=?,
       unit
     ) =>
-    t;
+    t =
+    "setValue";
 
-  let unsetLinkedRecords:
+  [@bs.send]
+  external setLinkedRecordToUndefined:
     (
       t,
+      [@bs.as {json|undefined|json}] _,
       ~name: string,
-      ~unsetValue: unsetValueType,
       ~arguments: arguments=?,
       unit
     ) =>
-    t;
+    t =
+    "setLinkedRecord";
+
+  [@bs.send]
+  external setLinkedRecordToNull:
+    (
+      t,
+      [@bs.as {json|null|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
+    "setLinkedRecord";
+
+  [@bs.send]
+  external setLinkedRecordsToUndefined:
+    (
+      t,
+      [@bs.as {json|undefined|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
+    "setLinkedRecords";
+
+  [@bs.send]
+  external setLinkedRecordsToNull:
+    (
+      t,
+      [@bs.as {json|null|json}] _,
+      ~name: string,
+      ~arguments: arguments=?,
+      unit
+    ) =>
+    t =
+    "setLinkedRecords";
 
   let invalidateRecord: t => unit;
 };

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -421,24 +421,19 @@ module Observable: {
     closed: bool,
   };
 
-  type observer('response) = {
-    start: option(subscription => unit),
-    next: option('response => unit),
-    error: option(Js.Exn.t => unit),
-    complete: option(unit => unit),
-    unsubscribe: option(subscription => unit),
-  };
+  type observer('response);
 
-  let makeObserver:
+  [@bs.obj]
+  external makeObserver:
     (
       ~start: subscription => unit=?,
-      ~next: 't => unit=?,
+      ~next: 'response => unit=?,
       ~error: Js.Exn.t => unit=?,
       ~complete: unit => unit=?,
       ~unsubscribe: subscription => unit=?,
       unit
     ) =>
-    observer('t);
+    observer('response);
 
   [@bs.module "relay-runtime"] [@bs.scope "Observable"]
   external make: (sink('t) => option(subscription)) => t('t) = "create";

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -78,10 +78,10 @@ external storeRootId: dataId = "ROOT_ID";
 [@bs.module "relay-runtime"]
 external storeRootType: string = "ROOT_TYPE";
 
-let _cleanObjectFromUndefined: Js.t({..}) => Js.t({..});
-let _cleanVariables: 'a => 'a;
-let _convertObj:
-  ('a, Js.Dict.t(Js.Dict.t(Js.Dict.t(string))), 'b, 'c) => 'd;
+[@bs.module "./utils"]
+external convertObj:
+  ('a, Js.Dict.t(Js.Dict.t(Js.Dict.t(string))), 'b, 'c) => 'd =
+  "traverser";
 
 /**
  * Read the following section on working with the Relay store:
@@ -117,36 +117,44 @@ module RecordProxy: {
     (t, ~name: string, ~arguments: arguments=?, unit) => option(string) =
     "getValue";
 
-  let getValueStringArray:
+  [@bs.send] [@bs.return nullable]
+  external getValueStringArray:
     (t, ~name: string, ~arguments: arguments=?, unit) =>
-    option(array(option(string)));
+    option(array(option(string))) =
+    "getValue";
 
   [@bs.send] [@bs.return nullable]
   external getValueInt:
     (t, ~name: string, ~arguments: arguments=?, unit) => option(int) =
     "getValue";
 
-  let getValueIntArray:
+  [@bs.send] [@bs.return nullable]
+  external getValueIntArray:
     (t, ~name: string, ~arguments: arguments=?, unit) =>
-    option(array(option(int)));
+    option(array(option(int))) =
+    "getValue";
 
   [@bs.send] [@bs.return nullable]
   external getValueFloat:
     (t, ~name: string, ~arguments: arguments=?, unit) => option(float) =
     "getValue";
 
-  let getValueFloatArray:
+  [@bs.send] [@bs.return nullable]
+  external getValueFloatArray:
     (t, ~name: string, ~arguments: arguments=?, unit) =>
-    option(array(option(float)));
+    option(array(option(float))) =
+    "getValue";
 
   [@bs.send] [@bs.return nullable]
   external getValueBool:
     (t, ~name: string, ~arguments: arguments=?, unit) => option(bool) =
     "getValue";
 
-  let getValueBoolArray:
+  [@bs.send] [@bs.return nullable]
+  external getValueBoolArray:
     (t, ~name: string, ~arguments: arguments=?, unit) =>
-    option(array(option(bool)));
+    option(array(option(bool))) =
+    "getValue";
 
   [@bs.send]
   external setLinkedRecord:
@@ -286,7 +294,7 @@ module RecordProxy: {
     t =
     "setLinkedRecords";
 
-  let invalidateRecord: t => unit;
+  [@bs.send] external invalidateRecord: t => unit = "invalidateRecord";
 };
 
 /**
@@ -924,9 +932,11 @@ type fetchQueryOptions = {
   fetchPolicy: option(string),
 };
 
-let fetchQuery:
+[@bs.module "react-relay/hooks"]
+external fetchQuery:
   (Environment.t, queryNode, 'variables, option(fetchQueryOptions)) =>
-  Observable.t('response);
+  Observable.t('response) =
+  "fetchQuery";
 
 /**
  * SUBSCRIPTIONS


### PR DESCRIPTION
Thanks to `bs.as` allowing `undefined` in BS 8.2.0 I changed the API for `unsetValue` functions to `setValueToNull` / `SetValueToUndefined` which is a bit nicer to use I think and allows 0 runtime cost bindings.

I also cleaned the bindings again, used the naming convention we agreed on for internal raw types and functions, and use bs.obj and bs.deriving abstract instead of Js.t objects to have a more robust type-check and to avoid undefined fields in objects.

I think we're pretty close to not having to clean objects to remove undefined fields, maybe all that's left is to change the type of connections.

The next round of cleanup could be focused on reducing the number of `Curry` calls in the generated JS.