### PR TITLE
Generate commitLocalPayload for elgible queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # master
 
-
+- Generate a `commitLocalPayload` for any query annotated with `@raw_response_type`, to allow comitting local only payloads in a type safe way.
 - _BREAKING CHANGE_ replace unsetValue with setValueToUndefined and setValueToNull
-- clean bindings, renamed internal raw types and functions with names ending with `Raw`, 
-use abstract records instead of Js.t objects for a more robust type-check and to avoid undefined fields
+- clean bindings, renamed internal raw types and functions with names ending with `Raw`,
+  use abstract records instead of Js.t objects for a more robust type-check and to avoid undefined fields
 
 # 0.11.0
 

--- a/packages/reason-relay/__tests__/Test_localPayload-tests.js
+++ b/packages/reason-relay/__tests__/Test_localPayload-tests.js
@@ -1,0 +1,30 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+
+const { test_query } = require("./Test_localPayload.bs");
+
+describe("LocalPayload", () => {
+  test("commiting a local payload works", async () => {
+    queryMock.mockQuery({
+      name: "TestLocalPayloadQuery",
+      variables: {},
+      data: {
+        loggedInUser: {
+          firstName: "First",
+          avatarUrl: "avatar-url",
+        },
+      },
+    });
+
+    t.render(test_query());
+    await t.screen.findByText("Firstname: First");
+    await t.screen.findByText("Avatar: avatar-url");
+
+    t.fireEvent.click(t.screen.getByText("Update locally"));
+
+    await t.screen.findByText("Firstname: AnotherFirst");
+    await t.screen.findByText("Avatar: -");
+  });
+});

--- a/packages/reason-relay/__tests__/Test_localPayload.re
+++ b/packages/reason-relay/__tests__/Test_localPayload.re
@@ -1,0 +1,83 @@
+module Query = [%relay.query
+  {|
+    query TestLocalPayloadQuery @raw_response_type {
+      loggedInUser {
+        id
+        ...TestLocalPayload_user
+      }
+    }
+|}
+];
+
+/**
+ * Don't mind this fragment, it's mostly here to check that
+ * it's actually getting inlined into the types for the query
+ * payload we're committing locally below.
+ */
+module Fragment = [%relay.fragment
+  {|
+  fragment TestLocalPayload_user on User {
+    firstName
+    avatarUrl
+  }
+|}
+];
+
+module Test = {
+  [@react.component]
+  let make = () => {
+    let environment = ReasonRelay.useEnvironmentFromContext();
+    let data = Query.use(~variables=(), ());
+    let user = Fragment.use(data.loggedInUser.fragmentRefs);
+
+    <div>
+      <div> {React.string("Firstname: " ++ user.firstName)} </div>
+      <div>
+        {React.string(
+           "Avatar: "
+           ++ (
+             switch (user.avatarUrl) {
+             | Some(avatarUrl) => avatarUrl
+             | None => "-"
+             }
+           ),
+         )}
+      </div>
+      <button
+        onClick={_ => {
+          Query.commitLocalPayload(
+            ~environment,
+            ~variables=(),
+            ~payload={
+              loggedInUser: {
+                id: data.loggedInUser.id,
+                firstName: "AnotherFirst",
+                avatarUrl: None,
+              },
+            },
+          )
+        }}>
+        {React.string("Update locally")}
+      </button>
+    </div>;
+  };
+};
+
+let test_query = () => {
+  let network =
+    ReasonRelay.Network.makePromiseBased(
+      ~fetchFunction=RelayEnv.fetchQuery,
+      (),
+    );
+
+  let environment =
+    ReasonRelay.Environment.make(
+      ~network,
+      ~store=
+        ReasonRelay.Store.make(~source=ReasonRelay.RecordSource.make(), ()),
+      (),
+    );
+  ();
+
+  <TestProviders.Wrapper environment> <Test /> </TestProviders.Wrapper>;
+};

--- a/packages/reason-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.re
@@ -45,6 +45,22 @@ let wrap_response_member:
   | `UnselectedUnionMember(v) => {"__typename": v};
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"loggedInUser_createdAt":{"c":"TestsUtils.Datetime"},"loggedInUser_friends_createdAt":{"c":"TestsUtils.Datetime"},"member":{"n":"","u":"response_member"},"member_user_createdAt":{"c":"TestsUtils.Datetime"}}} |json}
+  ];
+  let wrapResponseConverterMap = {
+    "TestsUtils.Datetime": TestsUtils.Datetime.serialize,
+    "response_member": wrap_response_member,
+  };
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"loggedInUser_createdAt":{"c":"TestsUtils.Datetime"},"loggedInUser_friends_createdAt":{"c":"TestsUtils.Datetime"},"member":{"n":"","u":"response_member"},"member_user_createdAt":{"c":"TestsUtils.Datetime"}}} |json}
@@ -60,6 +76,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestFragmentQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestFragmentQuery_graphql.re
@@ -24,6 +24,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"loggedInUser":{"f":""},"users":{"n":""},"users_edges":{"n":"","na":""},"users_edges_node":{"n":"","f":""},"users_edges_node_onlineStatus":{"n":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"loggedInUser":{"f":""},"users":{"n":""},"users_edges":{"n":"","na":""},"users_edges_node":{"n":"","f":""},"users_edges_node_onlineStatus":{"n":""}}} |json}
@@ -36,6 +49,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestLocalPayloadQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestLocalPayloadQuery_graphql.re
@@ -3,11 +3,17 @@
 module Types = {
   [@ocaml.warning "-30"];
   type response_loggedInUser = {
-    fragmentRefs: ReasonRelay.fragmentRefs([ | `TestSubscription_user]),
+    id: string,
+    fragmentRefs: ReasonRelay.fragmentRefs([ | `TestLocalPayload_user]),
+  }
+  and rawResponse_loggedInUser = {
+    id: string,
+    firstName: string,
+    avatarUrl: option(string),
   };
 
   type response = {loggedInUser: response_loggedInUser};
-  type rawResponse = response;
+  type rawResponse = {loggedInUser: rawResponse_loggedInUser};
   type variables = unit;
 };
 
@@ -38,11 +44,31 @@ module Internal = {
         Js.undefined,
       );
 
-  type wrapRawResponseRaw = wrapResponseRaw;
-  let convertWrapRawResponse = convertWrapResponse;
+  type wrapRawResponseRaw;
+  let wrapRawResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"loggedInUser_avatarUrl":{"n":""}}} |json}
+  ];
+  let wrapRawResponseConverterMap = ();
+  let convertWrapRawResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapRawResponseConverter,
+        wrapRawResponseConverterMap,
+        Js.null,
+      );
 
-  type rawResponseRaw = responseRaw;
-  let convertRawResponse = convertResponse;
+  type rawResponseRaw;
+  let rawResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"loggedInUser_avatarUrl":{"n":""}}} |json}
+  ];
+  let rawResponseConverterMap = ();
+  let convertRawResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        rawResponseConverter,
+        rawResponseConverterMap,
+        Js.undefined,
+      );
 
   let variablesConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {} |json}
@@ -64,12 +90,20 @@ module Utils = {};
 type operationType = ReasonRelay.queryNode;
 
 let node: operationType = [%raw
-  {json| {
+  {json| (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "TestSubscriptionQuery",
+    "name": "TestLocalPayloadQuery",
     "selections": [
       {
         "alias": null,
@@ -79,10 +113,11 @@ let node: operationType = [%raw
         "name": "loggedInUser",
         "plural": false,
         "selections": [
+          (v0/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "TestSubscription_user"
+            "name": "TestLocalPayload_user"
           }
         ],
         "storageKey": null
@@ -95,7 +130,7 @@ let node: operationType = [%raw
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "TestSubscriptionQuery",
+    "name": "TestLocalPayloadQuery",
     "selections": [
       {
         "alias": null,
@@ -105,13 +140,7 @@ let node: operationType = [%raw
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
+          (v0/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -125,13 +154,6 @@ let node: operationType = [%raw
             "kind": "ScalarField",
             "name": "avatarUrl",
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "onlineStatus",
-            "storageKey": null
           }
         ],
         "storageKey": null
@@ -139,14 +161,15 @@ let node: operationType = [%raw
     ]
   },
   "params": {
-    "cacheID": "0d224392d0c9bfbffa6f96b9a87f03d1",
+    "cacheID": "d815eea59afda254bed2d1af9be06a9a",
     "id": null,
     "metadata": {},
-    "name": "TestSubscriptionQuery",
+    "name": "TestLocalPayloadQuery",
     "operationKind": "query",
-    "text": "query TestSubscriptionQuery {\n  loggedInUser {\n    ...TestSubscription_user\n    id\n  }\n}\n\nfragment TestSubscription_user on User {\n  id\n  firstName\n  avatarUrl\n  onlineStatus\n}\n"
+    "text": "query TestLocalPayloadQuery {\n  loggedInUser {\n    id\n    ...TestLocalPayload_user\n  }\n}\n\nfragment TestLocalPayload_user on User {\n  firstName\n  avatarUrl\n}\n"
   }
-} |json}
+};
+})() |json}
 ];
 
 include ReasonRelay.MakeLoadQuery({

--- a/packages/reason-relay/__tests__/__generated__/TestLocalPayload_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestLocalPayload_user_graphql.re
@@ -1,0 +1,62 @@
+/* @generated */
+
+module Types = {
+  [@ocaml.warning "-30"];
+
+  type fragment = {
+    firstName: string,
+    avatarUrl: option(string),
+  };
+};
+
+module Internal = {
+  type fragmentRaw;
+  let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"avatarUrl":{"n":""}}} |json}
+  ];
+  let fragmentConverterMap = ();
+  let convertFragment = v =>
+    v
+    ->ReasonRelay.convertObj(
+        fragmentConverter,
+        fragmentConverterMap,
+        Js.undefined,
+      );
+};
+
+type t;
+type fragmentRef;
+external getFragmentRef:
+  ReasonRelay.fragmentRefs([> | `TestLocalPayload_user]) => fragmentRef =
+  "%identity";
+
+module Utils = {};
+
+type operationType = ReasonRelay.fragmentNode;
+
+let node: operationType = [%raw
+  {json| {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TestLocalPayload_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "avatarUrl",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+} |json}
+];

--- a/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersMeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersMeQuery_graphql.re
@@ -10,6 +10,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {} |json}
@@ -22,6 +35,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMissingFieldHandlersQuery_graphql.re
@@ -13,6 +13,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","tnf":"User"}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","tnf":"User"}}} |json}
@@ -25,6 +38,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestMutationQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationQuery_graphql.re
@@ -12,6 +12,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"loggedInUser":{"f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"loggedInUser":{"f":""}}} |json}
@@ -24,6 +37,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestNodeInterfaceQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestNodeInterfaceQuery_graphql.re
@@ -13,6 +13,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","tnf":"User"}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","tnf":"User"}}} |json}
@@ -25,6 +38,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.re
@@ -18,6 +18,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","f":""}}} |json}
@@ -30,6 +43,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
@@ -11,27 +11,40 @@ module Types = {
   type response = {node: option(response_node)};
   type rawResponse = response;
   type refetchVariables = {
-    onlineStatuses: option(array(enum_OnlineStatus)),
     count: option(int),
     cursor: option(string),
+    onlineStatuses: option(array(enum_OnlineStatus)),
     id: option(string),
   };
   let makeRefetchVariables =
-      (~onlineStatuses=?, ~count=?, ~cursor=?, ~id=?, ()): refetchVariables => {
-    onlineStatuses,
+      (~count=?, ~cursor=?, ~onlineStatuses=?, ~id=?, ()): refetchVariables => {
     count,
     cursor,
+    onlineStatuses,
     id,
   };
   type variables = {
-    onlineStatuses: option(array(enum_OnlineStatus)),
     count: option(int),
     cursor: option(string),
+    onlineStatuses: option(array(enum_OnlineStatus)),
     id: string,
   };
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","f":""}}} |json}
@@ -45,11 +58,14 @@ module Internal = {
         Js.undefined,
       );
 
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
+
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;
 
   let variablesConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"onlineStatuses":{"n":""},"count":{"n":""},"cursor":{"n":""}}} |json}
+    {json| {"__root":{"count":{"n":""},"cursor":{"n":""},"onlineStatuses":{"n":""}}} |json}
   ];
   let variablesConverterMap = ();
   let convertVariables = v =>
@@ -67,10 +83,10 @@ module Utils = {
   external onlineStatus_toString: enum_OnlineStatus => string = "%identity";
   open Types;
   let makeVariables =
-      (~onlineStatuses=?, ~count=?, ~cursor=?, ~id, ()): variables => {
-    onlineStatuses,
+      (~count=?, ~cursor=?, ~onlineStatuses=?, ~id, ()): variables => {
     count,
     cursor,
+    onlineStatuses,
     id,
   };
 };

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.re
@@ -15,14 +15,14 @@ module Types = {
 
   type fragment = {
     friendsConnection: fragment_friendsConnection,
-    id: option(string),
+    id: string,
   };
 };
 
 module Internal = {
   type fragmentRaw;
   let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"friendsConnection_edges":{"n":"","na":""},"friendsConnection_edges_node":{"n":"","f":""},"id":{"n":""}}} |json}
+    {json| {"__root":{"friendsConnection_edges":{"n":"","na":""},"friendsConnection_edges_node":{"n":"","f":""}}} |json}
   ];
   let fragmentConverterMap = ();
   let convertFragment = v =>

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.re
@@ -15,6 +15,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"":{"f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"":{"f":""}}} |json}
@@ -27,6 +40,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
@@ -10,28 +10,41 @@ module Types = {
   };
   type rawResponse = response;
   type refetchVariables = {
+    count: option(int),
+    cursor: option(string),
     groupId: option(string),
     onlineStatuses: option(array(enum_OnlineStatus)),
-    count: option(int),
-    cursor: option(string),
   };
   let makeRefetchVariables =
-      (~groupId=?, ~onlineStatuses=?, ~count=?, ~cursor=?, ())
+      (~count=?, ~cursor=?, ~groupId=?, ~onlineStatuses=?, ())
       : refetchVariables => {
-    groupId,
-    onlineStatuses,
     count,
     cursor,
+    groupId,
+    onlineStatuses,
   };
   type variables = {
-    groupId: string,
-    onlineStatuses: option(array(enum_OnlineStatus)),
     count: option(int),
     cursor: option(string),
+    groupId: string,
+    onlineStatuses: option(array(enum_OnlineStatus)),
   };
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"":{"f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"":{"f":""}}} |json}
@@ -45,11 +58,14 @@ module Internal = {
         Js.undefined,
       );
 
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
+
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;
 
   let variablesConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"onlineStatuses":{"n":""},"count":{"n":""},"cursor":{"n":""}}} |json}
+    {json| {"__root":{"count":{"n":""},"cursor":{"n":""},"onlineStatuses":{"n":""}}} |json}
   ];
   let variablesConverterMap = ();
   let convertVariables = v =>
@@ -67,11 +83,11 @@ module Utils = {
   external onlineStatus_toString: enum_OnlineStatus => string = "%identity";
   open Types;
   let makeVariables =
-      (~groupId, ~onlineStatuses=?, ~count=?, ~cursor=?, ()): variables => {
-    groupId,
-    onlineStatuses,
+      (~count=?, ~cursor=?, ~groupId, ~onlineStatuses=?, ()): variables => {
     count,
     cursor,
+    groupId,
+    onlineStatuses,
   };
 };
 

--- a/packages/reason-relay/__tests__/__generated__/TestQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestQuery_graphql.re
@@ -24,6 +24,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"users":{"n":""},"users_edges":{"n":"","na":""},"users_edges_node":{"n":""},"users_edges_node_onlineStatus":{"n":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"users":{"n":""},"users_edges":{"n":"","na":""},"users_edges_node":{"n":""},"users_edges_node_onlineStatus":{"n":""}}} |json}
@@ -36,6 +49,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.re
@@ -17,6 +17,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","tnf":"User","f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","tnf":"User","f":""}}} |json}
@@ -29,6 +42,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
@@ -11,25 +11,38 @@ module Types = {
   type response = {node: option(response_node)};
   type rawResponse = response;
   type refetchVariables = {
-    showOnlineStatus: option(bool),
     friendsOnlineStatuses: option(array(enum_OnlineStatus)),
+    showOnlineStatus: option(bool),
     id: option(string),
   };
   let makeRefetchVariables =
-      (~showOnlineStatus=?, ~friendsOnlineStatuses=?, ~id=?, ())
+      (~friendsOnlineStatuses=?, ~showOnlineStatus=?, ~id=?, ())
       : refetchVariables => {
-    showOnlineStatus,
     friendsOnlineStatuses,
+    showOnlineStatus,
     id,
   };
   type variables = {
-    showOnlineStatus: bool,
     friendsOnlineStatuses: array(enum_OnlineStatus),
+    showOnlineStatus: bool,
     id: string,
   };
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","f":""}}} |json}
@@ -42,6 +55,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;
@@ -65,9 +81,9 @@ module Utils = {
   external onlineStatus_toString: enum_OnlineStatus => string = "%identity";
   open Types;
   let makeVariables =
-      (~showOnlineStatus, ~friendsOnlineStatuses, ~id): variables => {
-    showOnlineStatus,
+      (~friendsOnlineStatuses, ~showOnlineStatus, ~id): variables => {
     friendsOnlineStatuses,
+    showOnlineStatus,
     id,
   };
 };

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.re
@@ -10,14 +10,14 @@ module Types = {
     firstName: string,
     onlineStatus: option(enum_OnlineStatus),
     friendsConnection: fragment_friendsConnection,
-    id: option(string),
+    id: string,
   };
 };
 
 module Internal = {
   type fragmentRaw;
   let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"onlineStatus":{"n":""},"id":{"n":""}}} |json}
+    {json| {"__root":{"onlineStatus":{"n":""}}} |json}
   ];
   let fragmentConverterMap = ();
   let convertFragment = v =>

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingQuery_graphql.re
@@ -12,6 +12,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"loggedInUser":{"f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"loggedInUser":{"f":""}}} |json}
@@ -24,6 +37,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.re
@@ -30,6 +30,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"node":{"n":"","f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"node":{"n":"","f":""}}} |json}
@@ -42,6 +55,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetching_user_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetching_user_graphql.re
@@ -10,14 +10,14 @@ module Types = {
     firstName: string,
     onlineStatus: option(enum_OnlineStatus),
     friendsConnection: fragment_friendsConnection,
-    id: option(string),
+    id: string,
   };
 };
 
 module Internal = {
   type fragmentRaw;
   let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
-    {json| {"__root":{"onlineStatus":{"n":""},"id":{"n":""}}} |json}
+    {json| {"__root":{"onlineStatus":{"n":""}}} |json}
   ];
   let fragmentConverterMap = ();
   let convertFragment = v =>

--- a/packages/reason-relay/__tests__/__generated__/TestUnionFragmentQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestUnionFragmentQuery_graphql.re
@@ -16,6 +16,19 @@ module Types = {
 };
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"member":{"n":"","f":""}}} |json}
+  ];
+  let wrapResponseConverterMap = ();
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"member":{"n":"","f":""}}} |json}
@@ -28,6 +41,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/__tests__/__generated__/TestUnionsQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestUnionsQuery_graphql.re
@@ -118,6 +118,22 @@ let wrap_response_members_edges_node:
   | `UnselectedUnionMember(v) => {"__typename": v};
 
 module Internal = {
+  type wrapResponseRaw;
+  let wrapResponseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"members":{"n":""},"members_edges":{"n":"","na":""},"members_edges_node":{"n":"","u":"response_members_edges_node"},"members_edges_node_user_onlineStatus":{"n":""},"members_edges_node_group_members":{"n":"","na":"","u":"response_members_edges_node_Group_members"},"members_edges_node_group_members_user_onlineStatus":{"n":""},"members_edges_node_group_members_group_avatarUrl":{"n":""},"members_edges_node_group_avatarUrl":{"n":""}}} |json}
+  ];
+  let wrapResponseConverterMap = {
+    "response_members_edges_node": wrap_response_members_edges_node,
+    "response_members_edges_node_Group_members": wrap_response_members_edges_node_Group_members,
+  };
+  let convertWrapResponse = v =>
+    v
+    ->ReasonRelay.convertObj(
+        wrapResponseConverter,
+        wrapResponseConverterMap,
+        Js.null,
+      );
+
   type responseRaw;
   let responseConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
     {json| {"__root":{"members":{"n":""},"members_edges":{"n":"","na":""},"members_edges_node":{"n":"","u":"response_members_edges_node"},"members_edges_node_user_onlineStatus":{"n":""},"members_edges_node_group_members":{"n":"","na":"","u":"response_members_edges_node_Group_members"},"members_edges_node_group_members_user_onlineStatus":{"n":""},"members_edges_node_group_members_group_avatarUrl":{"n":""},"members_edges_node_group_avatarUrl":{"n":""}}} |json}
@@ -133,6 +149,9 @@ module Internal = {
         responseConverterMap,
         Js.undefined,
       );
+
+  type wrapRawResponseRaw = wrapResponseRaw;
+  let convertWrapRawResponse = convertWrapResponse;
 
   type rawResponseRaw = responseRaw;
   let convertRawResponse = convertResponse;

--- a/packages/reason-relay/language-plugin/src/transformer/PrintState.re
+++ b/packages/reason-relay/language-plugin/src/transformer/PrintState.re
@@ -202,7 +202,6 @@ let getPrintedFullState =
   switch (state.response) {
   | Some(definition) =>
     switch (operationType) {
-    | Query(_)
     | Mutation(_) =>
       addToStr(
         TypesTransformerUtils.printConverterAssets(

--- a/packages/reason-relay/language-plugin/src/transformer/PrintState.re
+++ b/packages/reason-relay/language-plugin/src/transformer/PrintState.re
@@ -202,6 +202,7 @@ let getPrintedFullState =
   switch (state.response) {
   | Some(definition) =>
     switch (operationType) {
+    | Query(_)
     | Mutation(_) =>
       addToStr(
         TypesTransformerUtils.printConverterAssets(
@@ -230,6 +231,7 @@ let getPrintedFullState =
   switch (state.response, state.rawResponse) {
   | (Some(_), Some(definition)) =>
     switch (operationType) {
+    | Query(_)
     | Mutation(_) =>
       addToStr(
         TypesTransformerUtils.printConverterAssets(
@@ -254,6 +256,7 @@ let getPrintedFullState =
     addSpacing();
   | (Some(_), None) =>
     switch (operationType) {
+    | Query(_)
     | Mutation(_) =>
       addToStr(
         "type wrapRawResponseRaw = wrapResponseRaw;"

--- a/packages/reason-relay/reason-relay-ppx/library/ReasonRelayPpxLibrary.re
+++ b/packages/reason-relay/reason-relay-ppx/library/ReasonRelayPpxLibrary.re
@@ -17,6 +17,9 @@ let queryExtension =
 
       makeQuery(
         ~moduleName=operationStr |> extractTheQueryName(~loc=operationStrLoc),
+        ~hasRawResponseType=
+          operationStr
+          |> queryHasRawResponseTypeDirective(~loc=operationStrLoc),
         ~loc=operationStrLoc,
       );
     },

--- a/packages/reason-relay/src/ReasonRelay.re
+++ b/packages/reason-relay/src/ReasonRelay.re
@@ -402,6 +402,13 @@ module ConnectionHandler = {
 /**
  * QUERY
  */
+type operationDescriptor;
+
+[@bs.module "relay-runtime"]
+external internal_createOperationDescriptor:
+  (queryNode, 'variables) => operationDescriptor =
+  "createOperationDescriptor";
+
 module Disposable = {
   type t;
 
@@ -596,6 +603,9 @@ module Environment = {
     );
 
   [@bs.send] external getStore: t => Store.t = "getStore";
+  [@bs.send]
+  external commitPayload: (t, operationDescriptor, 'payload) => unit =
+    "commitPayload";
 };
 
 module Context = {

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -523,6 +523,16 @@ type renderPolicy =
   | Partial; // Allow rendering any fragments that already have the data needed
 
 /**
+ * Handle creating and using operation descriptors.
+ */
+type operationDescriptor;
+
+[@bs.module "relay-runtime"]
+external internal_createOperationDescriptor:
+  (queryNode, 'variables) => operationDescriptor =
+  "createOperationDescriptor";
+
+/**
  * Module representing the environment, which you'll need to use and
  * pass to various functions. Takes a few configuration options like store
  * and network layer.
@@ -551,6 +561,9 @@ module Environment: {
     t;
 
   [@bs.send] external getStore: t => Store.t = "getStore";
+  [@bs.send]
+  external commitPayload: (t, operationDescriptor, 'payload) => unit =
+    "commitPayload";
 };
 
 /**


### PR DESCRIPTION
This generates a `commitLocalPayload` for any query annotated with `@raw_response_type`, which lets you easily commit local only data in a type safe way as if it were an actual server response. This can be used for a bunch of things, most notably local state management via Relay.

The API looks roughly like this:

```
module Query = [%relay.query {|
  query SomeQuery {
    loggedInUser {
      lastActiveAt
    }
  }
|}];

...

Query.commitLocalPayload(~environment, ~variables=(), ~payload={ loggedInUser: { lastActive: someTimestamp } });
```

Check out the added test in this diff for another example/more info.