### PR TITLE
Propagate the error code for the relay-compiler

### DIFF
--- a/packages/reason-relay/compiler/compiler-cli.js
+++ b/packages/reason-relay/compiler/compiler-cli.js
@@ -22,7 +22,9 @@ if (!relayConfig.artifactDirectory) {
 function runRelayCompiler(args) {
   spawn("relay-compiler", args, {
     stdio: "inherit"
-  });
+  })
+    // Propagate the relay compiler's exit code.
+    .on('close', process.exit.bind(process));
 }
 
 function findArg(name) {


### PR DESCRIPTION
The reason-relay-compiler currently only exits with an error code when it 
detects an issue with its own configuration. In all other cases it exits with 
the status code 0.

This is problematic in cases where the error code is used in build pipelines. 
For example when a reason build should only be started if the relay compiler has 
completed successfully.
  
This commit propagates the error code from the child process of the 
relay-compiler to be the exit code of the reason-relay-compiler. This ensures 
that bash scripts such as `yarn reason-relay-compiler && bsb -make-world` work 
as a user may expect (only compile Reason when the Relay artifacts could be 
compiled).