### PR TITLE
Type list of connection IDs as dataId

### DIFF
--- a/packages/reason-relay-bin/bin/ReasonRelayBin.re
+++ b/packages/reason-relay-bin/bin/ReasonRelayBin.re
@@ -11,6 +11,8 @@ module GenerateFromFlow = {
   [@deriving yojson]
   type print_config = {
     [@default None]
+    variables_holding_connection_ids: option(list(string)),
+    [@default None]
     connection: option(connection_info),
   };
 
@@ -71,6 +73,8 @@ let () = {
             exit(1);
           },
         ~config={
+          variables_holding_connection_ids:
+            config.print_config.variables_holding_connection_ids,
           connection:
             switch (config.print_config.connection) {
             | None => None

--- a/packages/reason-relay-bin/copyIntoPlace.sh
+++ b/packages/reason-relay-bin/copyIntoPlace.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cp ./_esy/default/build/default/bin/ReasonRelayBin.exe ../reason-relay/language-plugin/
+cp -f ./_esy/default/build/default/bin/ReasonRelayBin.exe ../reason-relay/language-plugin/

--- a/packages/reason-relay-bin/lib/Types.re
+++ b/packages/reason-relay-bin/lib/Types.re
@@ -110,4 +110,7 @@ type fullState = {
   fragment: option(fragment),
 };
 
-type printConfig = {connection: option(connectionInfo)};
+type printConfig = {
+  variables_holding_connection_ids: option(list(string)),
+  connection: option(connectionInfo),
+};

--- a/packages/reason-relay/language-plugin/src/ReasonRelayBin.ts
+++ b/packages/reason-relay/language-plugin/src/ReasonRelayBin.ts
@@ -21,6 +21,7 @@ interface GenerateFromFlowConfig {
         fragment_value: [string, boolean];
       };
   print_config: {
+    variables_holding_connection_ids: null | string[];
     connection: null | {
       key: string;
       at_object_path: string[];

--- a/packages/reason-relay/language-plugin/src/RelayReasonGenerator.ts
+++ b/packages/reason-relay/language-plugin/src/RelayReasonGenerator.ts
@@ -53,6 +53,8 @@ export function generate(
           fragment_value: operationDescriptor.value,
         },
     print_config: {
+      variables_holding_connection_ids:
+        opInfo.variablesHoldingConnectionIds ?? null,
       connection: opInfo.connection
         ? {
             at_object_path: opInfo.connection.atObjectPath,

--- a/packages/reason-relay/language-plugin/src/__tests__/languagePlugin-tests.ts
+++ b/packages/reason-relay/language-plugin/src/__tests__/languagePlugin-tests.ts
@@ -229,6 +229,36 @@ describe("Language plugin tests", () => {
         expect(generated).toMatchSnapshot();
       });
     });
+
+    it("types ID as dataId for variables piped into the `connections` arg of the store updater directives", () => {
+      const generated = generate(`
+        mutation SetUserLocationMutation($input: SetUserLocationInput!, $connections: [ID!]!) {
+          setUserLocation(input: $input) {
+            changedUser @appendNode(connections: $connections) {
+              id
+              firstName
+            }
+          }
+        }
+      `);
+
+      expect(generated).toContain("connections: array(ReasonRelay.dataId),");
+    });
+
+    it("types ID as dataId for variables piped into the `connections` arg of the store updater directives, regardless of what the variable is named", () => {
+      const generated = generate(`
+        mutation SetUserLocationMutation($input: SetUserLocationInput!, $targetConns: [ID!]!) {
+          setUserLocation(input: $input) {
+            changedUser @prependNode(connections: $targetConns) {
+              id
+              firstName
+            }
+          }
+        }
+      `);
+
+      expect(generated).toContain("targetConns: array(ReasonRelay.dataId),");
+    });
   });
 
   describe("Mutation", () => {

--- a/packages/reason-relay/language-plugin/src/transformer/transformerUtils.ts
+++ b/packages/reason-relay/language-plugin/src/transformer/transformerUtils.ts
@@ -49,36 +49,43 @@ export function extractOperationInfo(node: Node | Fragment): printConfig {
           }
         }
 
-        /**
-         * Extract store updater directives
-         */
-        const storeUpdaterDirectivesWithConnectionsArg = n.directives.filter(
-          (d) =>
-            [
-              "appendNode",
-              "prependNode",
-              "appendEdge",
-              "prependEdge",
-              "deleteEdge",
-            ].includes(d.name)
-        );
+        if (
+          node.kind === "Root" &&
+          ["mutation", "subscription"].includes(node.operation)
+        ) {
+          /**
+           * Extract store updater directives
+           */
+          const storeUpdaterDirectivesWithConnectionsArg = n.directives.filter(
+            (d) =>
+              [
+                "appendNode",
+                "prependNode",
+                "appendEdge",
+                "prependEdge",
+                "deleteEdge",
+              ].includes(d.name)
+          );
 
-        if (storeUpdaterDirectivesWithConnectionsArg.length > 0) {
-          storeUpdaterDirectivesWithConnectionsArg.forEach((d) => {
-            const arg = d.args.find((a) => a.name === "connections");
+          if (storeUpdaterDirectivesWithConnectionsArg.length > 0) {
+            storeUpdaterDirectivesWithConnectionsArg.forEach((d) => {
+              const arg = d.args.find((a) => a.name === "connections");
 
-            const argValue = arg?.value;
+              const argValue = arg?.value;
 
-            if (argValue && argValue.kind === "Variable") {
-              if (opInfo.variablesHoldingConnectionIds) {
-                opInfo.variablesHoldingConnectionIds.push(
-                  argValue.variableName
-                );
-              } else {
-                opInfo.variablesHoldingConnectionIds = [argValue.variableName];
+              if (argValue && argValue.kind === "Variable") {
+                if (opInfo.variablesHoldingConnectionIds) {
+                  opInfo.variablesHoldingConnectionIds.push(
+                    argValue.variableName
+                  );
+                } else {
+                  opInfo.variablesHoldingConnectionIds = [
+                    argValue.variableName,
+                  ];
+                }
               }
-            }
-          });
+            });
+          }
         }
 
         path.push(n.name);

--- a/packages/reason-relay/language-plugin/src/transformer/transformerUtils.ts
+++ b/packages/reason-relay/language-plugin/src/transformer/transformerUtils.ts
@@ -6,6 +6,7 @@ type operationType = {
 };
 
 type printConfig = {
+  variablesHoldingConnectionIds?: null | string[];
   connection?: null | {
     key: string;
     atObjectPath: string[];
@@ -46,6 +47,38 @@ export function extractOperationInfo(node: Node | Fragment): printConfig {
               },
             };
           }
+        }
+
+        /**
+         * Extract store updater directives
+         */
+        const storeUpdaterDirectivesWithConnectionsArg = n.directives.filter(
+          (d) =>
+            [
+              "appendNode",
+              "prependNode",
+              "appendEdge",
+              "prependEdge",
+              "deleteEdge",
+            ].includes(d.name)
+        );
+
+        if (storeUpdaterDirectivesWithConnectionsArg.length > 0) {
+          storeUpdaterDirectivesWithConnectionsArg.forEach((d) => {
+            const arg = d.args.find((a) => a.name === "connections");
+
+            const argValue = arg?.value;
+
+            if (argValue && argValue.kind === "Variable") {
+              if (opInfo.variablesHoldingConnectionIds) {
+                opInfo.variablesHoldingConnectionIds.push(
+                  argValue.variableName
+                );
+              } else {
+                opInfo.variablesHoldingConnectionIds = [argValue.variableName];
+              }
+            }
+          });
         }
 
         path.push(n.name);


### PR DESCRIPTION
This is an attempt to tighten up the API some for working with the new store updater directives in Relay (`@appendEdge`, `@appendNode` and friends).

The store updater directives all work by accepting a list of connection IDs to add/remove edges/nodes from after a mutation or subscription has run. 

The part of this that trips people up usually is that it's the `dataId` of the connection Relay wants, not the connection key or anything else you as a user set up yourself. You get the `dataId` of a connection by asking for the `__id` field on the connection itself, which is Relay's `dataId`. It looks like this:

```
...some fragment...
myConnectionField(first: $count, after: $cursor) @connection(key: "SomeKey_goes_here") {
  __id # This will return the `dataId` for this connection
}
```

Now, with previous work we've made sure that the `__id` returned there is actually typed as a `dataId`, to signify that this is something you use to _interact with the store_, and not necessarily in any other way.

So, in practice what you'd do is pull out `__id` from the connection, and pass that into the `connections` argument of the new store updater directives. _But_, prior to this PR, you'd have to manually convert your `__id` `dataId` into a string for Relay to accept it passed in variables.

This PR ties together the that final loose end, by making sure that any variable that goes into the `connections` argument of a store updater directive is typed as `array(dataId)` instead of `array(string)`, tightening the API the way I initially intended.