### PR TITLE
Support comments on generated types

### DIFF
--- a/packages/reason-relay-bin/bin/ReasonRelayBin.re
+++ b/packages/reason-relay-bin/bin/ReasonRelayBin.re
@@ -81,7 +81,7 @@ let () = {
             | Some(conn) =>
               Some({
                 key: conn.key,
-                atObjectPath: conn.at_object_path,
+                atObjectPath: List.rev(conn.at_object_path),
                 fieldName: conn.field_name,
               })
             },

--- a/packages/reason-relay-bin/bin/ReasonRelayBin.re
+++ b/packages/reason-relay-bin/bin/ReasonRelayBin.re
@@ -4,7 +4,7 @@ module GenerateFromFlow = {
   [@deriving yojson]
   type connection_info = {
     key: string,
-    at_object_path: array(string),
+    at_object_path: list(string),
     field_name: string,
   };
 

--- a/packages/reason-relay-bin/lib/PrintState.re
+++ b/packages/reason-relay-bin/lib/PrintState.re
@@ -16,7 +16,12 @@ let transformVariables =
                  variable_name,
                  {
                    ...prop_value,
-                   propType: Array({nullable: false, propType: DataId}),
+                   propType:
+                     Array({
+                       comment: None,
+                       nullable: false,
+                       propType: DataId,
+                     }),
                  },
                )
              | v => v
@@ -350,10 +355,7 @@ let getPrintedFullState =
   // We print a helper for extracting connection nodes whenever there's a connection present.
   switch (config.connection) {
   | Some(connection) =>
-    let connPath =
-      connection.atObjectPath
-      |> Tablecloth.Array.to_list
-      |> Tablecloth.List.reverse;
+    let connPath = connection.atObjectPath |> List.rev;
 
     switch (
       state.objects

--- a/packages/reason-relay-bin/lib/PrintState.re
+++ b/packages/reason-relay-bin/lib/PrintState.re
@@ -64,7 +64,17 @@ let getPrintedFullState =
              Types.(
                ObjectTypeDeclaration({
                  name,
-                 definition: obj.definition,
+                 definition:
+                   switch (config.connection) {
+                   | Some({atObjectPath}) when atObjectPath == obj.atPath => {
+                       ...obj.definition,
+                       comment:
+                         Some(
+                           "Hint: You can extract all nodes from this connection to an array of non-nullable nodes using the `FragmentModule.getConnectionNodes` helper, like `let nodes = FragmentModule.getConnectionNodes(connectionGoesHere)`. `FragmentModule` is whatever you've named the module where you have defined your fragment.",
+                         ),
+                     }
+                   | _ => obj.definition
+                   },
                  atPath: obj.atPath,
                })
              ),
@@ -355,7 +365,7 @@ let getPrintedFullState =
   // We print a helper for extracting connection nodes whenever there's a connection present.
   switch (config.connection) {
   | Some(connection) =>
-    let connPath = connection.atObjectPath |> List.rev;
+    let connPath = connection.atObjectPath;
 
     switch (
       state.objects

--- a/packages/reason-relay-bin/lib/Printer.re
+++ b/packages/reason-relay-bin/lib/Printer.re
@@ -13,7 +13,7 @@ let makeWrapEnumFnName = enumName => "wrap_" ++ makeEnumName(enumName);
 
 let printComment = (comment: option(string)) =>
   switch (comment) {
-  | Some(comment) => "/* " ++ comment ++ " */\n"
+  | Some(comment) => "[@ocaml.doc \"" ++ comment ++ "\"] "
   | None => ""
   };
 
@@ -407,7 +407,7 @@ and printRootType =
       | Some(`Tail) => (" and ", "; ")
       };
 
-    prefix ++ typeDef ++ suffix;
+    printRecordComment(definition) ++ prefix ++ typeDef ++ suffix;
   | PluralFragment(Object(obj)) =>
     "type fragment_t = "
     ++ printObject(~obj, ~state, ~ignoreFragmentRefs, ())

--- a/packages/reason-relay-bin/lib/Printer.re
+++ b/packages/reason-relay-bin/lib/Printer.re
@@ -11,6 +11,17 @@ let makeEnumName = enumName => "enum_" ++ enumName;
 let makeUnwrapEnumFnName = enumName => "unwrap_" ++ makeEnumName(enumName);
 let makeWrapEnumFnName = enumName => "wrap_" ++ makeEnumName(enumName);
 
+let printComment = (comment: option(string)) =>
+  switch (comment) {
+  | Some(comment) => "/* " ++ comment ++ " */\n"
+  | None => ""
+  };
+
+let printRecordPropComment = (propValue: Types.propValue) =>
+  printComment(propValue.comment);
+
+let printRecordComment = (obj: Types.object_) => printComment(obj.comment);
+
 let printRecordPropName = propName =>
   switch (
     ReservedKeywords.reservedKeywords
@@ -180,7 +191,8 @@ and printObject = (~obj: object_, ~state, ~ignoreFragmentRefs=false, ()) => {
            addToStr(
              switch (p) {
              | Prop(name, propValue) =>
-               printRecordPropName(name)
+               printRecordPropComment(propValue)
+               ++ printRecordPropName(name)
                ++ ": "
                ++ printPropValue(~propValue, ~state)
                ++ ","
@@ -306,6 +318,7 @@ and printRefetchVariablesMaker = (obj: object_, ~state) => {
   let addToStr = s => str := str^ ++ s;
 
   let optionalObj = {
+    comment: None,
     atPath: [],
     values:
       obj.values
@@ -336,18 +349,21 @@ and printRootType =
     (~recursiveMode=None, ~state: fullState, ~ignoreFragmentRefs, rootType) => {
   switch (rootType) {
   | Operation(Object(obj)) =>
-    "type response = "
+    printRecordComment(obj)
+    ++ "type response = "
     ++ printObject(~obj, ~state, ~ignoreFragmentRefs, ())
     ++ ";"
   | RawResponse(Some(Object(obj))) =>
-    "type rawResponse = "
+    printRecordComment(obj)
+    ++ "type rawResponse = "
     ++ printObject(~obj, ~state, ~ignoreFragmentRefs, ())
     ++ ";"
   | RawResponse(None) => "type rawResponse = response;"
   | RawResponse(Some(Union(_)))
   | Operation(Union(_)) => raise(Invalid_top_level_shape)
   | Variables(Object(obj)) =>
-    "type variables = "
+    printRecordComment(obj)
+    ++ "type variables = "
     ++ printObject(~obj, ~state, ~ignoreFragmentRefs, ())
     ++ ";"
   | Variables(Union(_)) => raise(Invalid_top_level_shape)
@@ -358,11 +374,13 @@ and printRootType =
     }
 
   | Fragment(Object(obj)) =>
-    "type fragment = "
+    printRecordComment(obj)
+    ++ "type fragment = "
     ++ printObject(~obj, ~state, ~ignoreFragmentRefs, ())
     ++ ";"
   | Fragment(Union(union)) =>
-    "type fragment = "
+    printComment(union.comment)
+    ++ "type fragment = "
     ++ printUnionTypeDefinition(
          union,
          ~includeSemi=false,
@@ -394,6 +412,7 @@ and printRootType =
     "type fragment_t = "
     ++ printObject(~obj, ~state, ~ignoreFragmentRefs, ())
     ++ ";\n"
+    ++ printRecordComment(obj)
     ++ "type fragment = array(fragment_t);"
   | PluralFragment(Union(union)) =>
     "type fragment_t = "
@@ -403,6 +422,7 @@ and printRootType =
          ~prefixWithTypesModule=false,
        )
     ++ ";\n"
+    ++ printComment(union.comment)
     ++ "type fragment = array(fragment_t);"
   };
 }

--- a/packages/reason-relay-bin/lib/Types.re
+++ b/packages/reason-relay-bin/lib/Types.re
@@ -6,7 +6,7 @@ type operationType =
 
 type connectionInfo = {
   key: string,
-  atObjectPath: array(string),
+  atObjectPath: list(string),
   fieldName: string,
 };
 
@@ -15,6 +15,7 @@ type unionMember = {
   shape: object_,
 }
 and union = {
+  comment: option(string),
   members: list(unionMember),
   atPath: list(string),
 }
@@ -37,6 +38,7 @@ and propType =
   | Union(union)
   | TopLevelNodeField(string, object_)
 and propValue = {
+  comment: option(string),
   nullable: bool,
   propType,
 }
@@ -44,6 +46,7 @@ and propValues =
   | FragmentRef(string)
   | Prop(string, propValue)
 and object_ = {
+  comment: option(string),
   values: list(propValues),
   atPath: list(string),
 }

--- a/packages/reason-relay-bin/lib/Utils.re
+++ b/packages/reason-relay-bin/lib/Utils.re
@@ -75,6 +75,7 @@ let rec mapPropType = (~path, propType: propType): propType =>
   }
 and adjustObjectPath = (~path: list(string), obj: object_): object_ => {
   {
+    ...obj,
     atPath: path,
     values:
       obj.values

--- a/packages/reason-relay/language-plugin/src/__tests__/__snapshots__/languagePlugin-tests.ts.snap
+++ b/packages/reason-relay/language-plugin/src/__tests__/__snapshots__/languagePlugin-tests.ts.snap
@@ -809,6 +809,7 @@ exports[`Language plugin tests Query connections generates helpers for nested co
 
 module Types = {
   [@ocaml.warning \\"-30\\"];
+  /**Hint: You can extract all nodes from this connection to an array of non-nullable nodes using the \`FragmentModule.getConnectionNodes\` helper, like \`let nodes = FragmentModule.getConnectionNodes(connectionGoesHere)\`. \`FragmentModule\` is whatever you've named the module where you have defined your fragment.*/
   type fragment_me = {
     friendsConnection: option(fragment_me_friendsConnection),
   }


### PR DESCRIPTION
This adds support for comments on the generated types, and adding a comment to any connection record hinting that it's possible to use the generated `getConnectionNodes` helper to turn the connection into a non-nullable list of nodes.