### PR TITLE
Allow compiled code delivery use cases

### DIFF
--- a/build-ci.sh
+++ b/build-ci.sh
@@ -20,7 +20,6 @@ cp -rf src ../../_release;
 cp .npmignore ../../_release/;
 cp ../../README.md ../../_release/;
 cp ../../CHANGELOG.md ../../_release/;
-rm ../../_release/src/*.bs.js;
 
 # copy config files
 echo "Copying config files..."


### PR DESCRIPTION
Bundle prebuilt *.bs.js files into the release package to allow compiled code delivery use cases