### PR TITLE
Attempt to statically link executables

### DIFF
--- a/packages/reason-relay-bin/bin/dune
+++ b/packages/reason-relay-bin/bin/dune
@@ -2,5 +2,6 @@
  (name ReasonRelayBin)
  (public_name ReasonRelayBin)
  (libraries lib shexp.process yojson ppx_deriving_yojson.runtime)
+ (flags (:standard -ccopt -static -ccopt -Wl,--no-export-dynamic))
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/packages/reason-relay/reason-relay-ppx/bin/dune
+++ b/packages/reason-relay/reason-relay-ppx/bin/dune
@@ -2,7 +2,7 @@
     (modules (:standard \ ReasonRelayPpxBinPesyModules))
     (public_name ReasonRelayPpxApp.exe)
     (libraries reason-relay-ppx.bin.pesy-modules)
-    (flags -open ReasonRelayPpxBinPesyModules))
+    (flags (:standard -ccopt -static -ccopt -Wl,--no-export-dynamic -open ReasonRelayPpxBinPesyModules)))
 (library (public_name reason-relay-ppx.bin.pesy-modules)
     (name ReasonRelayPpxBinPesyModules)
     (modules ReasonRelayPpxBinPesyModules)


### PR DESCRIPTION
I think this should fix the glibc errors, and the executables don't seem to get too big.