### PR TITLE
[codex] Fix no-variable operations with provided variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+- Fix operations with no user supplied variables crashing when they include provided variables.
+
 # 4.4.1
 
 - Change name on internal fetch fn to avoid accidental shadowing.

--- a/packages/rescript-relay/__tests__/Test_mutation-tests.js
+++ b/packages/rescript-relay/__tests__/Test_mutation-tests.js
@@ -159,6 +159,47 @@ describe("Mutation", () => {
     await t.screen.findByText("First is idle");
   });
 
+  test("mutation with no variables can spread a provided variable fragment", async () => {
+    queryMock.mockQuery({
+      name: "TestMutationQuery",
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          firstName: "First",
+          lastName: "Name",
+          onlineStatus: "Online",
+          memberOf,
+        },
+      },
+    });
+
+    t.render(test_mutation());
+    await t.screen.findByText("Provided variable mutation status: -");
+
+    queryMock.mockQuery({
+      name: "TestMutationWithProvidedVariableFragmentMutation",
+      variables: {
+        __relay_internal__pv__ProvidedVariablesBool: true,
+      },
+      data: {
+        updateUserAvatar: {
+          user: {
+            id: "user-1",
+            someRandomArgField: "provided variable value",
+          },
+        },
+      },
+    });
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(
+        t.screen.getByText("Run mutation with provided variable fragment")
+      );
+    });
+
+    await t.screen.findByText("Provided variable mutation status: completed");
+  });
+
   test("optimistic response works", async () => {
     queryMock.mockQuery({
       name: "TestMutationQuery",

--- a/packages/rescript-relay/__tests__/Test_mutation.res
+++ b/packages/rescript-relay/__tests__/Test_mutation.res
@@ -29,6 +29,16 @@ module ComplexMutation = %relay(`
     }
 `)
 
+module MutationWithProvidedVariableFragment = %relay(`
+    mutation TestMutationWithProvidedVariableFragmentMutation {
+      updateUserAvatar {
+        user {
+          ...TestMutationProvidedVariable_user
+        }
+      }
+    }
+`)
+
 module MutationWithOnlyFragment = %relay(`
     mutation TestMutationWithOnlyFragmentSetOnlineStatusMutation($onlineStatus: OnlineStatus!) @raw_response_type {
       setOnlineStatus(onlineStatus: $onlineStatus) {
@@ -54,6 +64,15 @@ module Fragment = %relay(`
           name
         }
       }
+    }
+`)
+
+module ProvidedVariableFragment = %relay(`
+    fragment TestMutationProvidedVariable_user on User
+      @argumentDefinitions(
+        bool: { type: "Boolean!", provider: "ProvidedVariables.Bool" }
+      ) {
+      someRandomArgField(bool: $bool)
     }
 `)
 
@@ -84,6 +103,9 @@ module Test = {
     let data = Fragment.use(query.loggedInUser.fragmentRefs)
     let (mutate, isMutating) = Mutation.use()
     let (inlineStatus, setInlineStatus) = React.useState(_ => "-")
+    let (providedVariableMutationStatus, setProvidedVariableMutationStatus) = React.useState(_ =>
+      "-"
+    )
     let someJsonValue =
       [
         ("foo", JSON.Encode.null),
@@ -114,6 +136,11 @@ module Test = {
         }),
       )}
       <div> {React.string("Inline status: " ++ inlineStatus)} </div>
+      <div>
+        {React.string(
+          "Provided variable mutation status: " ++ providedVariableMutationStatus,
+        )}
+      </div>
       <button
         onClick={_ => {
           let _ = {
@@ -214,6 +241,20 @@ module Test = {
         }}
       >
         {React.string("Change online status, complex")}
+      </button>
+      <button
+        onClick={_ => {
+          open MutationWithProvidedVariableFragment
+          commitMutation(~environment, ~variables=(), ~onCompleted=(response, _) => {
+            switch response {
+            | {updateUserAvatar: Some({user: Some(_)})} =>
+              setProvidedVariableMutationStatus(_ => "completed")
+            | _ => setProvidedVariableMutationStatus(_ => "missing user")
+            }
+          })->RescriptRelay.Disposable.ignore
+        }}
+      >
+        {React.string("Run mutation with provided variable fragment")}
       </button>
       <button
         onClick={_ => {

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationProvidedVariable_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationProvidedVariable_user_graphql.res
@@ -1,0 +1,71 @@
+/* @sourceLoc Test_mutation.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type fragment = {
+    someRandomArgField: option<string>,
+  }
+}
+
+module Internal = {
+  @live
+  type fragmentRaw
+  @live
+  let fragmentConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let fragmentConverterMap = ()
+  @live
+  let convertFragment = v => v->RescriptRelay.convertObj(
+    fragmentConverter,
+    fragmentConverterMap,
+    None
+  )
+}
+
+type t
+type fragmentRef
+external getFragmentRef:
+  RescriptRelay.fragmentRefs<[> | #TestMutationProvidedVariable_user]> => fragmentRef = "%identity"
+
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.fragmentNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "__relay_internal__pv__ProvidedVariablesBool"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TestMutationProvidedVariable_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "bool",
+          "variableName": "__relay_internal__pv__ProvidedVariablesBool"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "someRandomArgField",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+} `)
+

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationWithProvidedVariableFragmentMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationWithProvidedVariableFragmentMutation_graphql.res
@@ -1,0 +1,201 @@
+/* @sourceLoc Test_mutation.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  @live
+  type rec response_updateUserAvatar_user = {
+    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestMutationProvidedVariable_user]>,
+  }
+  @live
+  and response_updateUserAvatar = {
+    user: option<response_updateUserAvatar_user>,
+  }
+  @live
+  type response = {
+    updateUserAvatar: option<response_updateUserAvatar>,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = unit
+}
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"updateUserAvatar_user":{"f":""}}}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"updateUserAvatar_user":{"f":""}}}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+@live type providedVariable<'t> = { providedVariable: unit => 't, get: unit => 't }
+@live type providedVariablesType = {
+  __relay_internal__pv__ProvidedVariablesBool: providedVariable<bool>,
+}
+@live let providedVariablesDefinition: providedVariablesType = {
+  __relay_internal__pv__ProvidedVariablesBool: {
+    providedVariable: ProvidedVariables.Bool.get,
+    get: ProvidedVariables.Bool.get,
+  },
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.mutationNode<relayOperationNode>
+
+
+%%private(let makeNode = (providedVariablesDefinition): operationType => {
+  ignore(providedVariablesDefinition)
+  %raw(json`{
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestMutationWithProvidedVariableFragmentMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UpdateUserAvatarPayload",
+        "kind": "LinkedField",
+        "name": "updateUserAvatar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TestMutationProvidedVariable_user"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "__relay_internal__pv__ProvidedVariablesBool"
+      }
+    ],
+    "kind": "Operation",
+    "name": "TestMutationWithProvidedVariableFragmentMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UpdateUserAvatarPayload",
+        "kind": "LinkedField",
+        "name": "updateUserAvatar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "bool",
+                    "variableName": "__relay_internal__pv__ProvidedVariablesBool"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "someRandomArgField",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a3f470a6bed8cef0adf39310f761636c",
+    "id": null,
+    "metadata": {},
+    "name": "TestMutationWithProvidedVariableFragmentMutation",
+    "operationKind": "mutation",
+    "text": "mutation TestMutationWithProvidedVariableFragmentMutation(\n  $__relay_internal__pv__ProvidedVariablesBool: Boolean!\n) {\n  updateUserAvatar {\n    user {\n      ...TestMutationProvidedVariable_user\n      id\n    }\n  }\n}\n\nfragment TestMutationProvidedVariable_user on User {\n  someRandomArgField(bool: $__relay_internal__pv__ProvidedVariablesBool)\n}\n",
+    "providedVariables": providedVariablesDefinition
+  }
+}`)
+})
+let node: operationType = makeNode(providedVariablesDefinition)
+
+

--- a/packages/rescript-relay/src/RescriptRelayReact.res
+++ b/packages/rescript-relay/src/RescriptRelayReact.res
@@ -61,7 +61,7 @@ module MakeLoadQuery = (C: MakeLoadQueryConfig) => {
     loadQuery(
       environment,
       C.query,
-      variables->C.convertVariables,
+      variables->C.convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
       {
         fetchKey,
         fetchPolicy,

--- a/packages/rescript-relay/src/RescriptRelay_Fragment.res
+++ b/packages/rescript-relay/src/RescriptRelay_Fragment.res
@@ -259,7 +259,7 @@ let useRefetchableFragment = (
           refetchFn(
             RescriptRelay_Internal.internal_removeUndefinedAndConvertNullsRaw(
               variables->convertRefetchVariables,
-            ),
+            )->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
             internal_makeRefetchableFnOpts(~fetchPolicy?, ~onComplete?, ()),
           ),
       [refetchFn],

--- a/packages/rescript-relay/src/RescriptRelay_Mutation.res
+++ b/packages/rescript-relay/src/RescriptRelay_Mutation.res
@@ -90,7 +90,7 @@ let commitMutation = (
         | None => None
         },
         ?uploadables,
-        variables: variables->convertVariables,
+        variables: variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
       },
     )
   }
@@ -136,7 +136,7 @@ let useMutation = (
             | None => None
             },
             ?uploadables,
-            variables: variables->convertVariables,
+            variables: variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
           })
         }
       }, [mutate]), mutating)

--- a/packages/rescript-relay/src/RescriptRelay_MutationNonReact.res
+++ b/packages/rescript-relay/src/RescriptRelay_MutationNonReact.res
@@ -39,7 +39,7 @@ let commitMutation = (
       environment,
       makeConfig(
         ~mutation=node,
-        ~variables=variables->convertVariables,
+        ~variables=variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
         ~onCompleted=?switch onCompleted {
         | Some(f) => Some((res, err) => f(res->convertResponse, err))
         | None => None

--- a/packages/rescript-relay/src/RescriptRelay_Query.res
+++ b/packages/rescript-relay/src/RescriptRelay_Query.res
@@ -57,7 +57,10 @@ let useLoader = (
     let loadQuery = React.useMemo1(
       () =>
         (~variables, ~fetchPolicy=?, ~networkCacheConfig=?) =>
-          loadQueryFn(variables->convertVariables, {?fetchPolicy, ?networkCacheConfig}),
+          loadQueryFn(
+            variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+            {?fetchPolicy, ?networkCacheConfig},
+          ),
       [loadQueryFn],
     )
     (nullableQueryRef->Nullable.toOption->mkQueryRef, loadQuery, disposableFn)
@@ -115,7 +118,7 @@ let fetch_ = (
     fetchQuery(
       environment,
       node,
-      variables->convertVariables,
+      variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
       Some({?networkCacheConfig, ?fetchPolicy}),
     )
     ->subscribe(
@@ -138,7 +141,7 @@ let fetchPromised = (
     fetchQuery(
       environment,
       node,
-      variables->convertVariables,
+      variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
       Some({?networkCacheConfig, ?fetchPolicy}),
     )
     ->Observable.toPromise
@@ -159,7 +162,12 @@ let retain = (~node, ~convertVariables: 'variables => 'variables) => {
                 store regardless of what happens (like it not being used by \
                 any view and therefore potentially garbage collected).*/
   (~environment: Environment.t, ~variables: 'variables) => {
-    environment->Environment.retain(createOperationDescriptor(node, variables->convertVariables))
+    environment->Environment.retain(
+      createOperationDescriptor(
+        node,
+        variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+      ),
+    )
   }
 }
 
@@ -174,7 +182,10 @@ let commitLocalPayload = (
                   hit the server for. */
   (~environment: Environment.t, ~variables: 'variables, ~payload: 'rawResponse) =>
     environment->Environment.commitPayload(
-      createOperationDescriptor(node, variables->convertVariables),
+      createOperationDescriptor(
+        node,
+        variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+      ),
       payload->convertWrapRawResponse,
     )
 }

--- a/packages/rescript-relay/src/RescriptRelay_QueryNonReact.res
+++ b/packages/rescript-relay/src/RescriptRelay_QueryNonReact.res
@@ -50,7 +50,7 @@ let fetch_ = (
     fetchQuery(
       environment,
       node,
-      variables->convertVariables,
+      variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
       Some({?networkCacheConfig, ?fetchPolicy}),
     )
     ->subscribe(
@@ -77,7 +77,7 @@ let fetchPromised = (
     fetchQuery(
       environment,
       node,
-      variables->convertVariables,
+      variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
       Some({?networkCacheConfig, ?fetchPolicy}),
     )
     ->toPromise
@@ -93,7 +93,12 @@ external commitPayload: (RescriptRelay.Environment.t, operationDescriptor, 'payl
 
 let retain = (~node, ~convertVariables: 'variables => 'variables) => {
   (~environment: RescriptRelay.Environment.t, ~variables: 'variables) =>
-    environment->retain_(createOperationDescriptor(node, variables->convertVariables))
+    environment->retain_(
+      createOperationDescriptor(
+        node,
+        variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+      ),
+    )
 }
 
 let commitLocalPayload = (
@@ -103,6 +108,9 @@ let commitLocalPayload = (
 ) =>
   (~environment: RescriptRelay.Environment.t, ~variables: 'variables, ~payload: 'rawResponse) =>
     environment->commitPayload(
-      createOperationDescriptor(node, variables->convertVariables),
+      createOperationDescriptor(
+        node,
+        variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+      ),
       payload->convertWrapRawResponse,
     )

--- a/packages/rescript-relay/src/RescriptRelay_Subscriptions.res
+++ b/packages/rescript-relay/src/RescriptRelay_Subscriptions.res
@@ -34,7 +34,7 @@ let subscribe = (
       {
         ?onCompleted,
         subscription: node,
-        variables: variables->convertVariables,
+        variables: variables->convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
         ?onError,
         onNext: ?switch onNext {
         | Some(onNext) => Some(response => onNext(response->convertResponse))


### PR DESCRIPTION
## Summary

Adds a regression test for a mutation that has no user-supplied variables but spreads a fragment with a Relay provided variable, then fixes the crash by normalizing converted operation variables before they are handed to Relay.

## Root Cause

For operations whose variables type is `unit`, ReScript emits JavaScript `undefined`. Relay expects operation variables to be an object and reads from `variables[def.name]` before applying `params.providedVariables`, so a no-variable mutation with only provided variables crashes while creating the operation descriptor.

## Changes

- Added a mutation repro that spreads a provided-variable fragment.
- Normalized converted operation variables through `internal_cleanObjectFromUndefinedRaw` before Relay calls.
- Applied the normalization consistently across mutation, query, subscription, preload/load, retain, local payload, and refetch paths.

## Validation

- `yarn build`
- `yarn test --runTestsByPath __tests__/Test_mutation-tests.js --runInBand`
- `yarn test:ci`