### PR TITLE
[codex] Normalize generated load query variables

### DIFF
--- a/packages/rescript-relay/__tests__/Test_mutation-tests.js
+++ b/packages/rescript-relay/__tests__/Test_mutation-tests.js
@@ -200,6 +200,49 @@ describe("Mutation", () => {
     await t.screen.findByText("Provided variable mutation status: completed");
   });
 
+  test("mutation hook with no variables can spread a provided variable fragment", async () => {
+    queryMock.mockQuery({
+      name: "TestMutationQuery",
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          firstName: "First",
+          lastName: "Name",
+          onlineStatus: "Online",
+          memberOf,
+        },
+      },
+    });
+
+    t.render(test_mutation());
+    await t.screen.findByText("Provided variable mutation status: -");
+
+    queryMock.mockQuery({
+      name: "TestMutationWithProvidedVariableFragmentMutation",
+      variables: {
+        __relay_internal__pv__ProvidedVariablesBool: true,
+      },
+      data: {
+        updateUserAvatar: {
+          user: {
+            id: "user-1",
+            someRandomArgField: "provided variable value",
+          },
+        },
+      },
+    });
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(
+        t.screen.getByText("Run mutation hook with provided variable fragment")
+      );
+    });
+
+    await t.screen.findByText(
+      "Provided variable mutation status: hook completed"
+    );
+  });
+
   test("optimistic response works", async () => {
     queryMock.mockQuery({
       name: "TestMutationQuery",

--- a/packages/rescript-relay/__tests__/Test_mutation.res
+++ b/packages/rescript-relay/__tests__/Test_mutation.res
@@ -102,6 +102,7 @@ module Test = {
     let query = Query.use(~variables=())
     let data = Fragment.use(query.loggedInUser.fragmentRefs)
     let (mutate, isMutating) = Mutation.use()
+    let (mutateWithProvidedVariableFragment, _) = MutationWithProvidedVariableFragment.use()
     let (inlineStatus, setInlineStatus) = React.useState(_ => "-")
     let (providedVariableMutationStatus, setProvidedVariableMutationStatus) = React.useState(_ =>
       "-"
@@ -255,6 +256,19 @@ module Test = {
         }}
       >
         {React.string("Run mutation with provided variable fragment")}
+      </button>
+      <button
+        onClick={_ => {
+          mutateWithProvidedVariableFragment(~variables=(), ~onCompleted=(response, _) => {
+            switch response {
+            | {updateUserAvatar: Some({user: Some(_)})} =>
+              setProvidedVariableMutationStatus(_ => "hook completed")
+            | _ => setProvidedVariableMutationStatus(_ => "hook missing user")
+            }
+          })->RescriptRelay.Disposable.ignore
+        }}
+      >
+        {React.string("Run mutation hook with provided variable fragment")}
       </button>
       <button
         onClick={_ => {

--- a/packages/rescript-relay/__tests__/Test_providedVariables-tests.js
+++ b/packages/rescript-relay/__tests__/Test_providedVariables-tests.js
@@ -7,35 +7,113 @@ const ReactTestUtils = require("react-dom/test-utils");
 const { test_providedVariables } = require("./Test_providedVariables.bs");
 
 describe("Provided variables", () => {
-  test("provided variables work", async () => {
+  const providedVariables = {
+    __relay_internal__pv__ProvidedVariablesBool: true,
+    __relay_internal__pv__ProvidedVariablesInputC: {
+      intStr: "123",
+      recursiveC: {
+        intStr: "234",
+      },
+    },
+    __relay_internal__pv__ProvidedVariablesInputCArr: [
+      {
+        intStr: "123",
+      },
+    ],
+    __relay_internal__pv__ProvidedVariablesIntStr: "456",
+    __relay_internal__pv__ProvidedVariablesIntStrArr: ["456"],
+  };
+
+  const mockProvidedVariablesQuery = (someRandomArgField) =>
     queryMock.mockQuery({
       name: "TestProvidedVariablesQuery",
-      variables: {
-        __relay_internal__pv__ProvidedVariablesBool: true,
-        __relay_internal__pv__ProvidedVariablesInputC: {
-          intStr: "123",
-          recursiveC: {
-            intStr: "234",
-          },
-        },
-        __relay_internal__pv__ProvidedVariablesInputCArr: [
-          {
-            intStr: "123",
-          },
-        ],
-        __relay_internal__pv__ProvidedVariablesIntStr: "456",
-        __relay_internal__pv__ProvidedVariablesIntStrArr: ["456"],
-      },
+      variables: providedVariables,
       data: {
         loggedInUser: {
           __typename: "User",
           id: "user-1",
-          someRandomArgField: "hello",
+          someRandomArgField,
         },
       },
     });
 
+  test("provided variables work", async () => {
+    mockProvidedVariablesQuery("hello");
+
     t.render(test_providedVariables());
     await t.screen.findByText("hello");
+  });
+
+  test("loading a no-variable query with provided variables from the raw module works", async () => {
+    mockProvidedVariablesQuery("hello");
+
+    t.render(test_providedVariables());
+    await t.screen.findByText("hello");
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(t.screen.getByText("Test provided variable raw load"));
+    });
+
+    await t.screen.findByText("Preloaded provided variable: hello");
+  });
+
+  test("loading a no-variable query with provided variables through useLoader works", async () => {
+    mockProvidedVariablesQuery("hello");
+
+    t.render(test_providedVariables());
+    await t.screen.findByText("hello");
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(
+        t.screen.getByText("Test provided variable query loader")
+      );
+    });
+
+    await t.screen.findByText("Preloaded provided variable: hello");
+  });
+
+  test("fetching a no-variable query with provided variables works", async () => {
+    mockProvidedVariablesQuery("hello");
+
+    t.render(test_providedVariables());
+    await t.screen.findByText("hello");
+
+    mockProvidedVariablesQuery("fetch");
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(t.screen.getByText("Test provided variable fetch"));
+    });
+
+    await t.screen.findByText("Provided variable fetch status: fetch");
+  });
+
+  test("fetching a no-variable query with provided variables as a promise works", async () => {
+    mockProvidedVariablesQuery("hello");
+
+    t.render(test_providedVariables());
+    await t.screen.findByText("hello");
+
+    mockProvidedVariablesQuery("fetch promised");
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(
+        t.screen.getByText("Test provided variable fetch promised")
+      );
+    });
+
+    await t.screen.findByText("Provided variable fetch status: fetch promised");
+  });
+
+  test("retaining a no-variable query with provided variables works", async () => {
+    mockProvidedVariablesQuery("hello");
+
+    t.render(test_providedVariables());
+    await t.screen.findByText("hello");
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(t.screen.getByText("Test provided variable retain"));
+    });
+
+    await t.screen.findByText("Provided variable retain status: retained");
   });
 });

--- a/packages/rescript-relay/__tests__/Test_providedVariables.res
+++ b/packages/rescript-relay/__tests__/Test_providedVariables.res
@@ -28,13 +28,84 @@ module Query = %relay(`
     }
 `)
 
+module TestPreloaded = {
+  @react.component
+  let make = (~queryRef) => {
+    let query = Query.usePreloaded(~queryRef)
+    let user = Fragment.use(query.loggedInUser.fragmentRefs)
+
+    <div>
+      {React.string(
+        "Preloaded provided variable: " ++ user.someRandomArgField->Option.getOr("-"),
+      )}
+    </div>
+  }
+}
+
 module Test = {
   @react.component
   let make = () => {
+    let environment = RescriptRelayReact.useEnvironmentFromContext()
     let query = Query.use(~variables=())
     let user = Fragment.use(query.loggedInUser.fragmentRefs)
+    let (queryRefFromModule, setQueryRefFromModule) = React.useState(() => None)
+    let (fetchedStatus, setFetchedStatus) = React.useState(() => "-")
+    let (retainedStatus, setRetainedStatus) = React.useState(() => "-")
+    let (loadedQueryRef, loadQuery, _dispose) = Query.useLoader()
 
-    <div> {React.string(user.someRandomArgField->Option.getOr("-"))} </div>
+    <div>
+      <div> {React.string(user.someRandomArgField->Option.getOr("-"))} </div>
+      <div> {React.string("Provided variable fetch status: " ++ fetchedStatus)} </div>
+      <div> {React.string("Provided variable retain status: " ++ retainedStatus)} </div>
+      <button
+        onClick={_ =>
+          setQueryRefFromModule(_ => Some(
+            TestProvidedVariablesQuery_graphql.load(
+              ~environment,
+              ~variables=(),
+              ~fetchPolicy=NetworkOnly,
+            ),
+          ))}
+      >
+        {React.string("Test provided variable raw load")}
+      </button>
+      <button onClick={_ => loadQuery(~variables=(), ~fetchPolicy=NetworkOnly)}>
+        {React.string("Test provided variable query loader")}
+      </button>
+      <button
+        onClick={_ =>
+          Query.fetch(~environment, ~variables=(), ~onResult=result =>
+            switch result {
+            | Ok(_) => setFetchedStatus(_ => "fetch")
+            | Error(_) => setFetchedStatus(_ => "fetch error")
+            }
+          )}
+      >
+        {React.string("Test provided variable fetch")}
+      </button>
+      <button
+        onClick={_ => {
+          let _ =
+            Query.fetchPromised(~environment, ~variables=())->Promise.thenResolve(_ =>
+              setFetchedStatus(_ => "fetch promised")
+            )
+        }}
+      >
+        {React.string("Test provided variable fetch promised")}
+      </button>
+      <button
+        onClick={_ => {
+          Query.retain(~environment, ~variables=())->RescriptRelay.Disposable.dispose
+          setRetainedStatus(_ => "retained")
+        }}
+      >
+        {React.string("Test provided variable retain")}
+      </button>
+      {switch (queryRefFromModule, loadedQueryRef) {
+      | (_, Some(queryRef)) | (Some(queryRef), _) => <TestPreloaded queryRef />
+      | _ => React.null
+      }}
+    </div>
   }
 }
 

--- a/packages/rescript-relay/__tests__/Test_subscription-tests.js
+++ b/packages/rescript-relay/__tests__/Test_subscription-tests.js
@@ -78,4 +78,51 @@ describe("Subscription", () => {
 
     await t.screen.findByText("Ready - User First is offline");
   });
+
+  test("subscription with no variables can spread a provided variable fragment", async () => {
+    queryMock.mockQuery({
+      name: "TestSubscriptionQuery",
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          firstName: "First",
+          avatarUrl: null,
+          onlineStatus: "Online",
+        },
+      },
+    });
+
+    const testAssets = test_subscription();
+
+    t.render(testAssets.render());
+    await t.screen.findByText("Ready - User First is online");
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(
+        t.screen.getByText("Subscribe with provided variable fragment")
+      );
+    });
+
+    expect(testAssets.getLastSubscriptionVariables()).toEqual({
+      __relay_internal__pv__ProvidedVariablesBool: true,
+    });
+
+    ReactTestUtils.act(() => {
+      testAssets.pushNext({
+        data: {
+          userUpdated: {
+            user: {
+              id: "user-1",
+              onlineStatus: "Online",
+              someRandomArgField: "provided variable value",
+            },
+          },
+        },
+      });
+    });
+
+    await t.screen.findByText(
+      "Provided variable subscription status: received"
+    );
+  });
 });

--- a/packages/rescript-relay/__tests__/Test_subscription.res
+++ b/packages/rescript-relay/__tests__/Test_subscription.res
@@ -27,6 +27,27 @@ module UserUpdatedSubscription = %relay(`
   }
 `)
 
+module SubscriptionWithProvidedVariableFragment = %relay(`
+  subscription TestSubscriptionWithProvidedVariableFragmentSubscription {
+    userUpdated(id: "user-1") {
+      user {
+        id
+        onlineStatus
+        ...TestSubscriptionProvidedVariable_user
+      }
+    }
+  }
+`)
+
+module ProvidedVariableFragment = %relay(`
+  fragment TestSubscriptionProvidedVariable_user on User
+    @argumentDefinitions(
+      bool: { type: "Boolean!", provider: "ProvidedVariables.Bool" }
+    ) {
+    someRandomArgField(bool: $bool)
+  }
+`)
+
 module Test = {
   @react.component
   let make = () => {
@@ -34,6 +55,8 @@ module Test = {
     let query = Query.use(~variables=())
     let data = Fragment.use(query.loggedInUser.fragmentRefs)
     let (ready, setReady) = React.useState(() => false)
+    let (providedVariableSubscriptionStatus, setProvidedVariableSubscriptionStatus) =
+      React.useState(() => "-")
 
     React.useEffect0(() => {
       let disposable = UserUpdatedSubscription.subscribe(
@@ -89,6 +112,27 @@ module Test = {
       | Some(avatarUrl) => <img alt="avatar" src=avatarUrl />
       | None => React.null
       }}
+      <div>
+        {React.string(
+          "Provided variable subscription status: " ++ providedVariableSubscriptionStatus,
+        )}
+      </div>
+      <button
+        onClick={_ => {
+          SubscriptionWithProvidedVariableFragment.subscribe(
+            ~environment,
+            ~variables=(),
+            ~onNext=response =>
+              switch response {
+              | {userUpdated: Some({user: Some(_)})} =>
+                setProvidedVariableSubscriptionStatus(_ => "received")
+              | _ => setProvidedVariableSubscriptionStatus(_ => "missing user")
+              },
+          )->RescriptRelay.Disposable.ignore
+        }}
+      >
+        {React.string("Subscribe with provided variable fragment")}
+      </button>
     </div>
   }
 }
@@ -96,6 +140,7 @@ module Test = {
 @live
 let test_subscription = () => {
   let subscriptionFns = ref([])
+  let subscriptionVariables = ref(([]: array<JSON.t>))
 
   let subscribeToOnNext = nextFn => {
     let _ = subscriptionFns.contents->Array.push(nextFn)
@@ -107,7 +152,9 @@ let test_subscription = () => {
 
   let pushNext = next => subscriptionFns.contents->Array.forEach(fn => fn(next))
 
-  let subscriptionFunction = (_, _, _) => {
+  let subscriptionFunction = (_, variables, _) => {
+    let _ = subscriptionVariables.contents->Array.push(variables)
+
     RescriptRelay.Observable.make(sink => {
       let unsubscribe = subscribeToOnNext(next => sink.next(next))
       Some({
@@ -130,6 +177,13 @@ let test_subscription = () => {
   {
     "pushNext": pushNext,
     "subscriptionFunction": subscriptionFunction,
+    "getLastSubscriptionVariables": () => {
+      let len = subscriptionVariables.contents->Array.length
+
+      len > 0
+        ? subscriptionVariables.contents->Array.getUnsafe(len - 1)
+        : JSON.Encode.object(dict{})
+    },
     "render": () =>
       <TestProviders.Wrapper environment>
         <Test />

--- a/packages/rescript-relay/__tests__/Test_subscription.resi
+++ b/packages/rescript-relay/__tests__/Test_subscription.resi
@@ -1,6 +1,7 @@
 @live
 let test_subscription: unit => {
+  "getLastSubscriptionVariables": unit => JSON.t,
   "pushNext": JSON.t => unit,
   "render": unit => React.element,
-  "subscriptionFunction": ('b, 'c, 'd) => RescriptRelay.Observable.t<JSON.t>,
+  "subscriptionFunction": ('b, JSON.t, 'd) => RescriptRelay.Observable.t<JSON.t>,
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscriptionProvidedVariable_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscriptionProvidedVariable_user_graphql.res
@@ -1,0 +1,71 @@
+/* @sourceLoc Test_subscription.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type fragment = {
+    someRandomArgField: option<string>,
+  }
+}
+
+module Internal = {
+  @live
+  type fragmentRaw
+  @live
+  let fragmentConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let fragmentConverterMap = ()
+  @live
+  let convertFragment = v => v->RescriptRelay.convertObj(
+    fragmentConverter,
+    fragmentConverterMap,
+    None
+  )
+}
+
+type t
+type fragmentRef
+external getFragmentRef:
+  RescriptRelay.fragmentRefs<[> | #TestSubscriptionProvidedVariable_user]> => fragmentRef = "%identity"
+
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.fragmentNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "__relay_internal__pv__ProvidedVariablesBool"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TestSubscriptionProvidedVariable_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "bool",
+          "variableName": "__relay_internal__pv__ProvidedVariablesBool"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "someRandomArgField",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+} `)
+

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscriptionWithProvidedVariableFragmentSubscription_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscriptionWithProvidedVariableFragmentSubscription_graphql.res
@@ -1,0 +1,221 @@
+/* @sourceLoc Test_subscription.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  @live
+  type rec response_userUpdated_user = {
+    @live id: string,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestSubscriptionProvidedVariable_user]>,
+  }
+  @live
+  and response_userUpdated = {
+    user: option<response_userUpdated_user>,
+  }
+  @live
+  type response = {
+    userUpdated: option<response_userUpdated>,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = unit
+}
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"userUpdated_user":{"f":""}}}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+  @live
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
+  @live
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
+  @live
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    onlineStatus_decode(Obj.magic(str))
+  }
+}
+@live type providedVariable<'t> = { providedVariable: unit => 't, get: unit => 't }
+@live type providedVariablesType = {
+  __relay_internal__pv__ProvidedVariablesBool: providedVariable<bool>,
+}
+@live let providedVariablesDefinition: providedVariablesType = {
+  __relay_internal__pv__ProvidedVariablesBool: {
+    providedVariable: ProvidedVariables.Bool.get,
+    get: ProvidedVariables.Bool.get,
+  },
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.subscriptionNode<relayOperationNode>
+
+
+%%private(let makeNode = (providedVariablesDefinition): operationType => {
+  ignore(providedVariablesDefinition)
+  %raw(json`(function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "user-1"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "onlineStatus",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestSubscriptionWithProvidedVariableFragmentSubscription",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "UserUpdatedPayload",
+        "kind": "LinkedField",
+        "name": "userUpdated",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TestSubscriptionProvidedVariable_user"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "userUpdated(id:\"user-1\")"
+      }
+    ],
+    "type": "Subscription",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "__relay_internal__pv__ProvidedVariablesBool"
+      }
+    ],
+    "kind": "Operation",
+    "name": "TestSubscriptionWithProvidedVariableFragmentSubscription",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "UserUpdatedPayload",
+        "kind": "LinkedField",
+        "name": "userUpdated",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "bool",
+                    "variableName": "__relay_internal__pv__ProvidedVariablesBool"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "someRandomArgField",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "userUpdated(id:\"user-1\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "07e00d76114780c061b4e56778d3b859",
+    "id": null,
+    "metadata": {},
+    "name": "TestSubscriptionWithProvidedVariableFragmentSubscription",
+    "operationKind": "subscription",
+    "text": "subscription TestSubscriptionWithProvidedVariableFragmentSubscription(\n  $__relay_internal__pv__ProvidedVariablesBool: Boolean!\n) {\n  userUpdated(id: \"user-1\") {\n    user {\n      id\n      onlineStatus\n      ...TestSubscriptionProvidedVariable_user\n    }\n  }\n}\n\nfragment TestSubscriptionProvidedVariable_user on User {\n  someRandomArgField(bool: $__relay_internal__pv__ProvidedVariablesBool)\n}\n",
+    "providedVariables": providedVariablesDefinition
+  }
+};
+})()`)
+})
+let node: operationType = makeNode(providedVariablesDefinition)
+
+

--- a/packages/rescript-relay/src/RescriptRelayReact.res
+++ b/packages/rescript-relay/src/RescriptRelayReact.res
@@ -32,8 +32,16 @@ type loadQueryConfig = {
 }
 
 @module("react-relay")
-external loadQuery: (Environment.t, queryNode<'a>, 'variables, loadQueryConfig) => 'queryResponse =
+external loadQuery_: (Environment.t, queryNode<'a>, 'variables, loadQueryConfig) => 'queryResponse =
   "loadQuery"
+
+let loadQuery = (environment, query, variables, config) =>
+  loadQuery_(
+    environment,
+    query,
+    variables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+    config,
+  )
 
 module type MakeLoadQueryConfig = {
   type variables
@@ -61,7 +69,7 @@ module MakeLoadQuery = (C: MakeLoadQueryConfig) => {
     loadQuery(
       environment,
       C.query,
-      variables->C.convertVariables->RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+      variables->C.convertVariables,
       {
         fetchKey,
         fetchPolicy,


### PR DESCRIPTION
## Summary

- Normalize variables inside the public `RescriptRelayReact.loadQuery` wrapper so generated `*.load` helpers pass `{}` instead of `undefined` for no-variable operations.
- Add provided-variable coverage for no-variable query paths, including generated raw load, `useLoader`, `fetch`, `fetchPromised`, and `retain`.
- Add no-variable provided-variable coverage for `useMutation` and subscriptions.

## Root Cause

Generated query `load` helpers call `RescriptRelayReact.loadQuery` directly with `variables->Internal.convertVariables`. For operations whose user variables type is `unit`, that conversion can produce `undefined`; Relay then crashes while resolving provided variables from that value.

## Validation

- `yarn build:test`
- `yarn build`
- `yarn test --runTestsByPath __tests__/Test_providedVariables-tests.js __tests__/Test_mutation-tests.js __tests__/Test_subscription-tests.js --runInBand`
- `yarn test:ci`