### PR TITLE
[codex] Add typed Relay testing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+- Add typed testing helpers for Relay tests:
+  - `Fragment.Test.fromData` for rendering non-inline fragment components with typed data in tests, Storybook, and local examples.
+  - `RescriptRelay_Test.createMockEnvironment` plus generated query helpers for operations using both `@relay_test_operation` and `@raw_response_type`.
+
 # 4.4.2
 
 - Fix operations with no user supplied variables crashing when they include provided variables.

--- a/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
@@ -1,6 +1,7 @@
 require("@testing-library/jest-dom/extend-expect");
 const t = require("@testing-library/react");
 const ReactTestUtils = require("react-dom/test-utils");
+const RescriptRelayTest = require("../src/RescriptRelay_Test.bs");
 const TestFragmentRef = require("../src/RescriptRelay_TestFragmentRef.bs");
 const { InlineFragment } = require("./Test_fragment.bs");
 const PluralFragmentArtifact = require("./__generated__/TestTestingHelpers_plural_user_graphql.bs");
@@ -57,6 +58,16 @@ describe("Testing helpers", () => {
 
   test("inline fragments do not expose synthetic data helpers", () => {
     expect(InlineFragment.Test).toBeUndefined();
+  });
+
+  test("resolveMostRecentOperation passes Relay a payload resolver", () => {
+    const payload = { loggedInUser: { firstName: "Resolved" } };
+    const mock = { resolveMostRecentOperation: jest.fn() };
+
+    RescriptRelayTest.resolveMostRecentOperation({ mock }, payload);
+
+    expect(mock.resolveMostRecentOperation).toHaveBeenCalledWith(expect.any(Function));
+    expect(mock.resolveMostRecentOperation.mock.calls[0][0]()).toEqual({ data: payload });
   });
 
   test("typed query test helpers resolve a mock environment operation", async () => {

--- a/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
@@ -2,6 +2,7 @@ require("@testing-library/jest-dom/extend-expect");
 const t = require("@testing-library/react");
 const ReactTestUtils = require("react-dom/test-utils");
 const TestFragmentRef = require("../src/RescriptRelay_TestFragmentRef.bs");
+const { InlineFragment } = require("./Test_fragment.bs");
 const PluralFragmentArtifact = require("./__generated__/TestTestingHelpers_plural_user_graphql.bs");
 
 const {
@@ -52,6 +53,10 @@ describe("Testing helpers", () => {
     expect(TestFragmentRef.getDataForNode(PluralFragmentArtifact.node, copiedRef)).toEqual(
       users
     );
+  });
+
+  test("inline fragments do not expose synthetic data helpers", () => {
+    expect(InlineFragment.Test).toBeUndefined();
   });
 
   test("typed query test helpers resolve a mock environment operation", async () => {

--- a/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
@@ -1,0 +1,53 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const ReactTestUtils = require("react-dom/test-utils");
+
+const {
+  synthetic,
+  syntheticOpt,
+  syntheticPlural,
+  environment,
+  queryHelpers,
+  interleaved,
+  resolveQueryHelpers,
+} = require("./Test_testingHelpers.bs");
+
+describe("Testing helpers", () => {
+  test("synthetic fragment refs render without a Relay provider", async () => {
+    t.render(synthetic());
+    await t.screen.findByText("Synthetic User");
+  });
+
+  test("synthetic fragment refs work with useOpt", async () => {
+    t.render(syntheticOpt());
+    await t.screen.findByText("Synthetic via opt");
+  });
+
+  test("synthetic plural fragment refs render without a Relay provider", async () => {
+    t.render(syntheticPlural());
+    await t.screen.findByText("Plural Synthetic is online");
+  });
+
+  test("typed query test helpers resolve a mock environment operation", async () => {
+    const relayEnvironment = environment();
+    t.render(queryHelpers(relayEnvironment));
+
+    ReactTestUtils.act(() => {
+      resolveQueryHelpers(relayEnvironment);
+    });
+
+    await t.screen.findByText("Typed from query helper");
+  });
+
+  test("synthetic and real fragment refs can be rendered side by side", async () => {
+    const relayEnvironment = environment();
+    t.render(interleaved(relayEnvironment));
+
+    ReactTestUtils.act(() => {
+      resolveQueryHelpers(relayEnvironment);
+    });
+
+    await t.screen.findByText("Interleaved Synthetic User");
+    await t.screen.findByText("Typed Real");
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
@@ -44,7 +44,7 @@ describe("Testing helpers", () => {
     const users = [
       { id: "synthetic-user-4", firstName: "Copied Synthetic", onlineStatus: "Online" },
     ];
-    const copiedRef = TestFragmentRef.makePlural(
+    const copiedRef = TestFragmentRef.make(
       "TestTestingHelpers_plural_user",
       users
     ).slice();

--- a/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
@@ -40,6 +40,20 @@ describe("Testing helpers", () => {
     expect(TestFragmentRef.getDataForNode(PluralFragmentArtifact.node, [])).toBeUndefined();
   });
 
+  test("copied non-empty synthetic plural fragment ref arrays remain synthetic", () => {
+    const users = [
+      { id: "synthetic-user-4", firstName: "Copied Synthetic", onlineStatus: "Online" },
+    ];
+    const copiedRef = TestFragmentRef.makePlural(
+      "TestTestingHelpers_plural_user",
+      users
+    ).slice();
+
+    expect(TestFragmentRef.getDataForNode(PluralFragmentArtifact.node, copiedRef)).toEqual(
+      users
+    );
+  });
+
   test("typed query test helpers resolve a mock environment operation", async () => {
     const relayEnvironment = environment();
     t.render(queryHelpers(relayEnvironment));

--- a/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers-tests.js
@@ -1,11 +1,14 @@
 require("@testing-library/jest-dom/extend-expect");
 const t = require("@testing-library/react");
 const ReactTestUtils = require("react-dom/test-utils");
+const TestFragmentRef = require("../src/RescriptRelay_TestFragmentRef.bs");
+const PluralFragmentArtifact = require("./__generated__/TestTestingHelpers_plural_user_graphql.bs");
 
 const {
   synthetic,
   syntheticOpt,
   syntheticPlural,
+  syntheticEmptyPlural,
   environment,
   queryHelpers,
   interleaved,
@@ -26,6 +29,15 @@ describe("Testing helpers", () => {
   test("synthetic plural fragment refs render without a Relay provider", async () => {
     t.render(syntheticPlural());
     await t.screen.findByText("Plural Synthetic is online");
+  });
+
+  test("empty synthetic plural fragment refs render without a Relay provider", () => {
+    const { container } = t.render(syntheticEmptyPlural());
+    expect(container.firstChild).toBeEmptyDOMElement();
+  });
+
+  test("empty real plural fragment ref arrays are not treated as synthetic", () => {
+    expect(TestFragmentRef.getDataForNode(PluralFragmentArtifact.node, [])).toBeUndefined();
   });
 
   test("typed query test helpers resolve a mock environment operation", async () => {

--- a/packages/rescript-relay/__tests__/Test_testingHelpers.res
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers.res
@@ -137,6 +137,9 @@ let syntheticPlural = () =>
   />
 
 @live
+let syntheticEmptyPlural = () => <SyntheticPlural users={PluralFragment.Test.fromData([])} />
+
+@live
 let environment = () => RescriptRelay_Test.createMockEnvironment()
 
 @live

--- a/packages/rescript-relay/__tests__/Test_testingHelpers.res
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers.res
@@ -1,0 +1,167 @@
+module SubFragment = %relay(`
+  fragment TestTestingHelpers_sub_user on User @rescriptRelayIgnoreUnused {
+    lastName
+  }
+`)
+
+module Fragment = %relay(`
+  fragment TestTestingHelpers_user on User {
+    __id
+    firstName
+    onlineStatus
+    ...TestTestingHelpers_sub_user
+  }
+`)
+
+module PluralFragment = %relay(`
+  fragment TestTestingHelpers_plural_user on User @relay(plural: true) {
+    id
+    firstName
+    onlineStatus
+  }
+`)
+
+module Query = %relay(`
+  query TestTestingHelpersQuery @relay_test_operation @raw_response_type {
+    loggedInUser {
+      id
+      firstName
+      onlineStatus
+      ...TestTestingHelpers_user
+    }
+  }
+`)
+
+module Synthetic = {
+  @react.component
+  let make = (~user) => {
+    let data = Fragment.use(user)
+    let subData = SubFragment.use(data.fragmentRefs)
+    <div> {React.string(data.firstName ++ " " ++ subData.lastName)} </div>
+  }
+}
+
+module SyntheticOpt = {
+  @react.component
+  let make = (~user) => {
+    let data = Fragment.useOpt(Some(user))
+    <div>
+      {switch data {
+      | Some(data) => React.string(data.firstName ++ " via opt")
+      | None => React.string("No data")
+      }}
+    </div>
+  }
+}
+
+module SyntheticPlural = {
+  @react.component
+  let make = (~users) => {
+    let allUsers = PluralFragment.use(users)
+
+    <div>
+      {allUsers
+      ->Array.map(user =>
+        <div key=user.id>
+          {React.string(
+            user.firstName ++
+            (" is " ++
+            switch user.onlineStatus {
+            | Some(Online) => "online"
+            | Some(Offline) => "offline"
+            | Some(Idle) | Some(FutureAddedValue(_)) | None => "-"
+            }),
+          )}
+        </div>
+      )
+      ->React.array}
+    </div>
+  }
+}
+
+module QueryHelpers = {
+  @react.component
+  let make = () => {
+    let data = Query.use(~variables=())
+    <div> {React.string(data.loggedInUser.firstName ++ " from query helper")} </div>
+  }
+}
+
+module Interleaved = {
+  @react.component
+  let make = () => {
+    let data = Query.use(~variables=())
+
+    <div>
+      <Synthetic
+        user={Fragment.Test.fromData({
+          __id: RescriptRelay.makeDataId("interleaved-synthetic-user"),
+          firstName: "Interleaved Synthetic",
+          onlineStatus: Some(Online),
+          fragmentRefs: SubFragment.Test.fromData({lastName: "User"}),
+        })}
+      />
+      <Synthetic user=data.loggedInUser.fragmentRefs />
+    </div>
+  }
+}
+
+@live
+let synthetic = () =>
+  <Synthetic
+    user={Fragment.Test.fromData({
+      __id: RescriptRelay.makeDataId("synthetic-user-1"),
+      firstName: "Synthetic",
+      onlineStatus: Some(Online),
+      fragmentRefs: SubFragment.Test.fromData({lastName: "User"}),
+    })}
+  />
+
+@live
+let syntheticOpt = () =>
+  <SyntheticOpt
+    user={Fragment.Test.fromData({
+      __id: RescriptRelay.makeDataId("synthetic-user-2"),
+      firstName: "Synthetic",
+      onlineStatus: Some(Online),
+      fragmentRefs: SubFragment.Test.fromData({lastName: "User"}),
+    })}
+  />
+
+@live
+let syntheticPlural = () =>
+  <SyntheticPlural
+    users={PluralFragment.Test.fromData([
+      {id: "synthetic-user-3", firstName: "Plural Synthetic", onlineStatus: Some(Online)},
+    ])}
+  />
+
+@live
+let environment = () => RescriptRelay_Test.createMockEnvironment()
+
+@live
+let queryHelpers = environment =>
+  <TestProviders.Wrapper environment>
+    <QueryHelpers />
+  </TestProviders.Wrapper>
+
+@live
+let interleaved = environment =>
+  <TestProviders.Wrapper environment>
+    <Interleaved />
+  </TestProviders.Wrapper>
+
+@live
+let resolveQueryHelpers = environment =>
+  Query.Test.resolveMostRecentOperation(
+    ~environment,
+    ~payload={
+      loggedInUser: {
+        __id: Some(RescriptRelay.makeDataId("query-helper-user-1")),
+        id: "query-helper-user-1",
+        firstName: "Typed",
+        onlineStatus: Some(Online),
+        lastName: "Real",
+      },
+    },
+  )

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpersQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpersQuery_graphql.res
@@ -1,0 +1,313 @@
+/* @sourceLoc Test_testingHelpers.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type rec response_loggedInUser = {
+    firstName: string,
+    @live id: string,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestTestingHelpers_user]>,
+  }
+  @live
+  and rawResponse_loggedInUser = {
+    @live __id: option<RescriptRelay.dataId>,
+    firstName: string,
+    @live id: string,
+    lastName: string,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
+  }
+  type response = {
+    loggedInUser: response_loggedInUser,
+  }
+  @live
+  type rawResponse = {
+    loggedInUser: rawResponse_loggedInUser,
+  }
+  @live
+  type variables = unit
+  @live
+  type refetchVariables = unit
+  @live let makeRefetchVariables = () => ()
+}
+
+
+type queryRef
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"loggedInUser":{"f":""}}}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"loggedInUser":{"f":""}}}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  @live
+  type wrapRawResponseRaw
+  @live
+  let wrapRawResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapRawResponseConverterMap = ()
+  @live
+  let convertWrapRawResponse = v => v->RescriptRelay.convertObj(
+    wrapRawResponseConverter,
+    wrapRawResponseConverterMap,
+    null
+  )
+  @live
+  type rawResponseRaw
+  @live
+  let rawResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let rawResponseConverterMap = ()
+  @live
+  let convertRawResponse = v => v->RescriptRelay.convertObj(
+    rawResponseConverter,
+    rawResponseConverterMap,
+    None
+  )
+  type rawPreloadToken<'response> = {source: Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+  @live
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
+  @live
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
+  @live
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    onlineStatus_decode(Obj.magic(str))
+  }
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "firstName",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "onlineStatus",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestTestingHelpersQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          (v1/*: any*/),
+          (v2/*: any*/),
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "TestTestingHelpers_user"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TestTestingHelpersQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          (v1/*: any*/),
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "lastName",
+            "storageKey": null
+          },
+          {
+            "kind": "ClientExtension",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__id",
+                "storageKey": null
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "79d8f121d62e528a53256df555a012c8",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "loggedInUser": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "User"
+        },
+        "loggedInUser.__id": (v3/*: any*/),
+        "loggedInUser.firstName": (v4/*: any*/),
+        "loggedInUser.id": (v3/*: any*/),
+        "loggedInUser.lastName": (v4/*: any*/),
+        "loggedInUser.onlineStatus": {
+          "enumValues": [
+            "Online",
+            "Idle",
+            "offline"
+          ],
+          "nullable": true,
+          "plural": false,
+          "type": "OnlineStatus"
+        }
+      }
+    },
+    "name": "TestTestingHelpersQuery",
+    "operationKind": "query",
+    "text": "query TestTestingHelpersQuery {\n  loggedInUser {\n    id\n    firstName\n    onlineStatus\n    ...TestTestingHelpers_user\n  }\n}\n\nfragment TestTestingHelpers_sub_user on User {\n  lastName\n}\n\nfragment TestTestingHelpers_user on User {\n  firstName\n  onlineStatus\n  ...TestTestingHelpers_sub_user\n}\n"
+  }
+};
+})() `)
+
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelayReact.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Nullable.toOption
+}
+
+@live
+let queryRefToPromise = token => {
+  Promise.make((resolve, _reject) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok())))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpersQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpersQuery_graphql.res
@@ -299,7 +299,7 @@ let queryRefToObservable = token => {
   let raw = token->Internal.tokenToRaw
   raw.source->Nullable.toOption
 }
-
+  
 @live
 let queryRefToPromise = token => {
   Promise.make((resolve, _reject) => {

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_plural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_plural_user_graphql.res
@@ -91,3 +91,4 @@ let node: operationType = %raw(json` {
   "type": "User",
   "abstractKey": null
 } `)
+

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_plural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_plural_user_graphql.res
@@ -1,0 +1,93 @@
+/* @sourceLoc Test_testingHelpers.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type fragment_t = {
+    firstName: string,
+    @live id: string,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+  }
+  type fragment = array<fragment_t>
+}
+
+module Internal = {
+  @live
+  type fragmentRaw
+  @live
+  let fragmentConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let fragmentConverterMap = ()
+  @live
+  let convertFragment = v => v->RescriptRelay.convertObj(
+    fragmentConverter,
+    fragmentConverterMap,
+    None
+  )
+}
+
+type t
+type fragmentRef
+external getFragmentRef:
+  array<RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_plural_user]>> => fragmentRef = "%identity"
+
+module Utils = {
+  @@warning("-33")
+  open Types
+  @live
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
+  @live
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
+  @live
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    onlineStatus_decode(Obj.magic(str))
+  }
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.fragmentNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "TestTestingHelpers_plural_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "onlineStatus",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+} `)

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_sub_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_sub_user_graphql.res
@@ -57,3 +57,4 @@ let node: operationType = %raw(json` {
   "type": "User",
   "abstractKey": null
 } `)
+

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_sub_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_sub_user_graphql.res
@@ -1,0 +1,59 @@
+/* @sourceLoc Test_testingHelpers.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type fragment = {
+    @live lastName: string,
+  }
+}
+
+module Internal = {
+  @live
+  type fragmentRaw
+  @live
+  let fragmentConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let fragmentConverterMap = ()
+  @live
+  let convertFragment = v => v->RescriptRelay.convertObj(
+    fragmentConverter,
+    fragmentConverterMap,
+    None
+  )
+}
+
+type t
+type fragmentRef
+external getFragmentRef:
+  RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_sub_user]> => fragmentRef = "%identity"
+
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.fragmentNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TestTestingHelpers_sub_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lastName",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+} `)

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_user_graphql.res
@@ -1,0 +1,101 @@
+/* @sourceLoc Test_testingHelpers.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type fragment = {
+    @live __id: RescriptRelay.dataId,
+    firstName: string,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestTestingHelpers_sub_user]>,
+  }
+}
+
+module Internal = {
+  @live
+  type fragmentRaw
+  @live
+  let fragmentConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"":{"f":""}}}`
+  )
+  @live
+  let fragmentConverterMap = ()
+  @live
+  let convertFragment = v => v->RescriptRelay.convertObj(
+    fragmentConverter,
+    fragmentConverterMap,
+    None
+  )
+}
+
+type t
+type fragmentRef
+external getFragmentRef:
+  RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_user]> => fragmentRef = "%identity"
+
+module Utils = {
+  @@warning("-33")
+  open Types
+  @live
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
+  @live
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
+  @live
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    onlineStatus_decode(Obj.magic(str))
+  }
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.fragmentNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TestTestingHelpers_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "onlineStatus",
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "TestTestingHelpers_sub_user"
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__id",
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+} `)

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_user_graphql.res
@@ -99,3 +99,4 @@ let node: operationType = %raw(json` {
   "type": "User",
   "abstractKey": null
 } `)
+

--- a/packages/rescript-relay/package.json
+++ b/packages/rescript-relay/package.json
@@ -55,12 +55,14 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-relay": "20.1.1",
+    "relay-test-utils": "20.1.1",
     "relay-runtime": "20.1.1",
     "rescript": "12.0.0"
   },
   "peerDependencies": {
     "@rescript/react": ">=0.13.0",
     "react-relay": "20.1.1",
+    "relay-test-utils": "20.1.1",
     "relay-runtime": "20.1.1",
     "rescript": "^12.0.0-0"
   },
@@ -69,6 +71,9 @@
       "optional": true
     },
     "react-relay": {
+      "optional": true
+    },
+    "relay-test-utils": {
       "optional": true
     }
   },

--- a/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
@@ -22,15 +22,20 @@ let make ~loc ~moduleName ~refetchableQueryName
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] ->
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] =
                   [%e valFromGeneratedModule ["Internal"; "convertFragment"]]];
-              [%stri
-                module Test = struct
-                  let fromData
-                      (data :
-                        [%t typeFromGeneratedModule ["Types"; "fragment"]]) =
-                    RescriptRelay_TestFragmentRef.make
-                      [%e makeStringExpr ~loc moduleName] data
-                end];
             ];
+            (match hasInlineDirective with
+            | false ->
+              [
+                [%stri
+                  module Test = struct
+                    let fromData
+                        (data :
+                          [%t typeFromGeneratedModule ["Types"; "fragment"]]) =
+                      RescriptRelay_TestFragmentRef.make
+                        [%e makeStringExpr ~loc moduleName] data
+                  end];
+              ]
+            | true -> []);
             (match
                (NonReactUtils.enabled.contents, hasAutocodesplitDirective)
              with

--- a/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
@@ -22,26 +22,14 @@ let make ~loc ~moduleName ~refetchableQueryName
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] ->
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] =
                   [%e valFromGeneratedModule ["Internal"; "convertFragment"]]];
-              (if isPlural then
-               [%stri
-                 module Test = struct
-                     let fromData
-                         (data :
-                           [%t typeFromGeneratedModule ["Types"; "fragment"]])
-                         =
-                       RescriptRelay_TestFragmentRef.makePlural
-                         [%e makeStringExpr ~loc moduleName] data
-                   end]
-               else
-               [%stri
-                 module Test = struct
-                     let fromData
-                         (data :
-                           [%t typeFromGeneratedModule ["Types"; "fragment"]])
-                         =
-                       RescriptRelay_TestFragmentRef.make
-                         [%e makeStringExpr ~loc moduleName] data
-                   end]);
+              [%stri
+                module Test = struct
+                  let fromData
+                      (data :
+                        [%t typeFromGeneratedModule ["Types"; "fragment"]]) =
+                    RescriptRelay_TestFragmentRef.make
+                      [%e makeStringExpr ~loc moduleName] data
+                end];
             ];
             (match
                (NonReactUtils.enabled.contents, hasAutocodesplitDirective)

--- a/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
@@ -22,6 +22,26 @@ let make ~loc ~moduleName ~refetchableQueryName
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] ->
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] =
                   [%e valFromGeneratedModule ["Internal"; "convertFragment"]]];
+              (if isPlural then
+               [%stri
+                 module Test = struct
+                     let fromData
+                         (data :
+                           [%t typeFromGeneratedModule ["Types"; "fragment"]])
+                         =
+                       RescriptRelay_TestFragmentRef.makePlural
+                         [%e makeStringExpr ~loc moduleName] data
+                   end]
+               else
+               [%stri
+                 module Test = struct
+                     let fromData
+                         (data :
+                           [%t typeFromGeneratedModule ["Types"; "fragment"]])
+                         =
+                       RescriptRelay_TestFragmentRef.make
+                         [%e makeStringExpr ~loc moduleName] data
+                   end]);
             ];
             (match
                (NonReactUtils.enabled.contents, hasAutocodesplitDirective)

--- a/packages/rescript-relay/rescript-relay-ppx/library/Query.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Query.ml
@@ -1,7 +1,8 @@
 open Ppxlib
 open Util
 
-let make ~loc ~moduleName ~hasRawResponseType ~hasAutocodesplitDirective =
+let make ~loc ~moduleName ~hasRawResponseType ~hasRelayTestOperation
+    ~hasAutocodesplitDirective =
   let typeFromGeneratedModule = makeTypeAccessor ~loc ~moduleName in
   let valFromGeneratedModule = makeExprAccessor ~loc ~moduleName in
   let moduleIdentFromGeneratedModule = makeModuleIdent ~loc ~moduleName in
@@ -111,6 +112,25 @@ let make ~loc ~moduleName ~hasRawResponseType ~hasAutocodesplitDirective =
                         ~node:[%e valFromGeneratedModule ["node"]]]
                 | false -> [%stri ()]);
               ]);
+            (match (hasRawResponseType, hasRelayTestOperation) with
+            | true, true ->
+              [
+                [%stri
+                  module Test = struct
+                    let queuePendingOperation ~environment ~variables =
+                      RescriptRelay_Test.queuePendingOperation ~environment
+                        ~node:[%e valFromGeneratedModule ["node"]]
+                        ~variables:
+                          (RescriptRelay_Internal
+                           .internal_cleanObjectFromUndefinedRaw
+                             (convertVariables variables))
+
+                    let resolveMostRecentOperation ~environment ~payload =
+                      RescriptRelay_Test.resolveMostRecentOperation ~environment
+                        ~payload:(convertWrapRawResponse payload)
+                  end];
+              ]
+            | _ -> []);
             (match
                (NonReactUtils.enabled.contents, hasAutocodesplitDirective)
              with

--- a/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.ml
@@ -40,6 +40,8 @@ let commonExtension =
               (selection_set |> Util.hasAutocodesplitDirective)
             ~moduleName:(op |> extractTheQueryName ~loc)
             ~hasRawResponseType:(op |> queryHasRawResponseTypeDirective ~loc)
+            ~hasRelayTestOperation:
+              (op |> queryHasRelayTestOperationDirective ~loc)
             ~loc
       | Operation {optype = Mutation} ->
         Mutation.make ~moduleName:(op |> extractTheMutationName ~loc) ~loc

--- a/packages/rescript-relay/rescript-relay-ppx/library/Util.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Util.ml
@@ -89,6 +89,13 @@ let queryHasRawResponseTypeDirective ~loc op =
     |> List.exists (fun (directive : Graphql_parser.directive) ->
            directive.name = "raw_response_type")
   | _ -> false
+let queryHasRelayTestOperationDirective ~loc op =
+  match op with
+  | Graphql_parser.Operation {optype = Query; name = Some _; directives} ->
+    directives
+    |> List.exists (fun (directive : Graphql_parser.directive) ->
+           directive.name = "relay_test_operation")
+  | _ -> false
 let fragmentIsUpdatable op =
   match op with
   | Graphql_parser.Fragment {directives} ->

--- a/packages/rescript-relay/src/RescriptRelay_Fragment.res
+++ b/packages/rescript-relay/src/RescriptRelay_Fragment.res
@@ -15,7 +15,11 @@ let useFragment = (~node, ~convertFragment: 'fragment => 'fragment, ~fRef) => {
                      User @inline {...}`) and then use `Fragment.readInline`. \
                      This will allow you to get the fragment data, but outside \
                      of React's render.*/
-  (useFragment_(node, fRef)->RescriptRelay_Internal.internal_useConvertedValue(convertFragment, _))
+  switch RescriptRelay_TestFragmentRef.getDataForNode(node, fRef) {
+  | Some(data) => data
+  | None =>
+    useFragment_(node, fRef)->RescriptRelay_Internal.internal_useConvertedValue(convertFragment, _)
+  }
 }
 
 @module("react-relay")
@@ -29,14 +33,28 @@ let useFragmentOpt = (~fRef, ~node, ~convertFragment: 'fragment => 'fragment) =>
                      `option<fragmentRefs>` and get `option<'fragmentData>` \
                      back. Useful for scenarios where you don't have the \
                      fragmentRefs yet.*/
-  let data =
-    useFragmentOpt_(node, fRef)->Nullable.toOption
-  React.useMemo1(() => {
-    switch data {
-    | Some(data) => Some(convertFragment(data))
-    | None => None
+  switch fRef {
+  | Some(fRef) =>
+    switch RescriptRelay_TestFragmentRef.getDataForNode(node, fRef) {
+    | Some(data) => Some(data)
+    | None =>
+      let data = useFragmentOpt_(node, Some(fRef))->Nullable.toOption
+      React.useMemo1(() => {
+        switch data {
+        | Some(data) => Some(convertFragment(data))
+        | None => None
+        }
+      }, [data])
     }
-  }, [data])
+  | None =>
+    let data = useFragmentOpt_(node, None)->Nullable.toOption
+    React.useMemo1(() => {
+      switch data {
+      | Some(data) => Some(convertFragment(data))
+      | None => None
+      }
+    }, [data])
+  }
 }
 
 @module("react-relay")

--- a/packages/rescript-relay/src/RescriptRelay_Test.res
+++ b/packages/rescript-relay/src/RescriptRelay_Test.res
@@ -18,5 +18,5 @@ let resolveMostRecentOperation = (
 ) => {
   ignore(environment)
   ignore(payload)
-  ignore(%raw(`environment.mock.resolveMostRecentOperation({data: payload})`))
+  ignore(%raw(`environment.mock.resolveMostRecentOperation(() => ({data: payload}))`))
 }

--- a/packages/rescript-relay/src/RescriptRelay_Test.res
+++ b/packages/rescript-relay/src/RescriptRelay_Test.res
@@ -1,0 +1,22 @@
+@module("relay-test-utils")
+external createMockEnvironment: unit => RescriptRelay.Environment.t = "createMockEnvironment"
+
+let queuePendingOperation = (
+  ~environment: RescriptRelay.Environment.t,
+  ~node: RescriptRelay.queryNode<'node>,
+  ~variables: 'variables,
+) => {
+  ignore(environment)
+  ignore(node)
+  ignore(variables)
+  ignore(%raw(`environment.mock.queuePendingOperation(node, variables)`))
+}
+
+let resolveMostRecentOperation = (
+  ~environment: RescriptRelay.Environment.t,
+  ~payload: 'rawResponse,
+) => {
+  ignore(environment)
+  ignore(payload)
+  ignore(%raw(`environment.mock.resolveMostRecentOperation({data: payload})`))
+}

--- a/packages/rescript-relay/src/RescriptRelay_Test.resi
+++ b/packages/rescript-relay/src/RescriptRelay_Test.resi
@@ -1,0 +1,12 @@
+let createMockEnvironment: unit => RescriptRelay.Environment.t
+
+let queuePendingOperation: (
+  ~environment: RescriptRelay.Environment.t,
+  ~node: RescriptRelay.queryNode<'node>,
+  ~variables: 'variables,
+) => unit
+
+let resolveMostRecentOperation: (
+  ~environment: RescriptRelay.Environment.t,
+  ~payload: 'rawResponse,
+) => unit

--- a/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
+++ b/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
@@ -1,21 +1,26 @@
 let make = (fragmentName: string, data: 'fragment): 'fragmentRefs => {
   ignore(fragmentName)
   ignore(data)
-  %raw(`({__rescriptRelaySyntheticFragmentRef: true, fragmentName, data})`)
-}
+  %raw(`
+    (() => {
+      const makeSingular = data => ({
+        __rescriptRelaySyntheticFragmentRef: true,
+        fragmentName,
+        data
+      });
 
-let makePlural = (fragmentName: string, data: array<'fragment>): array<'fragmentRefs> => {
-  ignore(fragmentName)
-  let fragmentRefs = data->Array.map(fragment => make(fragmentName, fragment))
-  ignore(
-    %raw(`
+      if (Array.isArray(data)) {
+        const fragmentRefs = data.map(makeSingular);
       Object.defineProperties(fragmentRefs, {
         __rescriptRelaySyntheticFragmentRef: {value: true},
         fragmentName: {value: fragmentName}
-      })
-    `),
-  )
-  fragmentRefs
+        });
+        return fragmentRefs;
+      }
+
+      return makeSingular(data);
+    })()
+  `)
 }
 
 let getDataForNode = (node: 'node, fragmentRef: 'fragmentRef): option<'fragment> => {

--- a/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
+++ b/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
@@ -1,0 +1,46 @@
+let make = (fragmentName: string, data: 'fragment): 'fragmentRefs => {
+  ignore(fragmentName)
+  ignore(data)
+  %raw(`({__rescriptRelaySyntheticFragmentRef: true, fragmentName, data})`)
+}
+
+let makePlural = (fragmentName: string, data: array<'fragment>): array<'fragmentRefs> =>
+  data->Array.map(fragment => make(fragmentName, fragment))
+
+let getDataForNode = (node: 'node, fragmentRef: 'fragmentRef): option<'fragment> => {
+  ignore(node)
+  ignore(fragmentRef)
+  %raw(`
+    (() => {
+      const fragmentName = node.name;
+
+      if (
+        fragmentRef != null &&
+        typeof fragmentRef === "object" &&
+        fragmentRef.__rescriptRelaySyntheticFragmentRef === true &&
+        fragmentRef.fragmentName === fragmentName
+      ) {
+        return fragmentRef.data;
+      }
+
+      if (Array.isArray(fragmentRef)) {
+        const data = [];
+        for (let i = 0; i < fragmentRef.length; i++) {
+          const ref = fragmentRef[i];
+          if (
+            ref == null ||
+            typeof ref !== "object" ||
+            ref.__rescriptRelaySyntheticFragmentRef !== true ||
+            ref.fragmentName !== fragmentName
+          ) {
+            return undefined;
+          }
+          data.push(ref.data);
+        }
+        return data;
+      }
+
+      return undefined;
+    })()
+  `)
+}

--- a/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
+++ b/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
@@ -27,8 +27,11 @@ let getDataForNode = (node: 'node, fragmentRef: 'fragmentRef): option<'fragment>
 
       if (Array.isArray(fragmentRef)) {
         if (
-          fragmentRef.__rescriptRelaySyntheticFragmentRef !== true ||
-          fragmentRef.fragmentName !== fragmentName
+          fragmentRef.length === 0 &&
+          (
+            fragmentRef.__rescriptRelaySyntheticFragmentRef !== true ||
+            fragmentRef.fragmentName !== fragmentName
+          )
         ) {
           return undefined;
         }

--- a/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
+++ b/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.res
@@ -4,8 +4,19 @@ let make = (fragmentName: string, data: 'fragment): 'fragmentRefs => {
   %raw(`({__rescriptRelaySyntheticFragmentRef: true, fragmentName, data})`)
 }
 
-let makePlural = (fragmentName: string, data: array<'fragment>): array<'fragmentRefs> =>
-  data->Array.map(fragment => make(fragmentName, fragment))
+let makePlural = (fragmentName: string, data: array<'fragment>): array<'fragmentRefs> => {
+  ignore(fragmentName)
+  let fragmentRefs = data->Array.map(fragment => make(fragmentName, fragment))
+  ignore(
+    %raw(`
+      Object.defineProperties(fragmentRefs, {
+        __rescriptRelaySyntheticFragmentRef: {value: true},
+        fragmentName: {value: fragmentName}
+      })
+    `),
+  )
+  fragmentRefs
+}
 
 let getDataForNode = (node: 'node, fragmentRef: 'fragmentRef): option<'fragment> => {
   ignore(node)
@@ -14,16 +25,14 @@ let getDataForNode = (node: 'node, fragmentRef: 'fragmentRef): option<'fragment>
     (() => {
       const fragmentName = node.name;
 
-      if (
-        fragmentRef != null &&
-        typeof fragmentRef === "object" &&
-        fragmentRef.__rescriptRelaySyntheticFragmentRef === true &&
-        fragmentRef.fragmentName === fragmentName
-      ) {
-        return fragmentRef.data;
-      }
-
       if (Array.isArray(fragmentRef)) {
+        if (
+          fragmentRef.__rescriptRelaySyntheticFragmentRef !== true ||
+          fragmentRef.fragmentName !== fragmentName
+        ) {
+          return undefined;
+        }
+
         const data = [];
         for (let i = 0; i < fragmentRef.length; i++) {
           const ref = fragmentRef[i];
@@ -38,6 +47,15 @@ let getDataForNode = (node: 'node, fragmentRef: 'fragmentRef): option<'fragment>
           data.push(ref.data);
         }
         return data;
+      }
+
+      if (
+        fragmentRef != null &&
+        typeof fragmentRef === "object" &&
+        fragmentRef.__rescriptRelaySyntheticFragmentRef === true &&
+        fragmentRef.fragmentName === fragmentName
+      ) {
+        return fragmentRef.data;
       }
 
       return undefined;

--- a/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.resi
+++ b/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.resi
@@ -1,5 +1,3 @@
 let make: (string, 'fragment) => 'fragmentRefs
 
-let makePlural: (string, array<'fragment>) => array<'fragmentRefs>
-
 let getDataForNode: ('node, 'fragmentRef) => option<'fragment>

--- a/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.resi
+++ b/packages/rescript-relay/src/RescriptRelay_TestFragmentRef.resi
@@ -1,0 +1,5 @@
+let make: (string, 'fragment) => 'fragmentRefs
+
+let makePlural: (string, array<'fragment>) => array<'fragmentRefs>
+
+let getDataForNode: ('node, 'fragmentRef) => option<'fragment>

--- a/packages/rescript-relay/yarn.lock
+++ b/packages/rescript-relay/yarn.lock
@@ -3770,6 +3770,16 @@ relay-runtime@20.1.1:
     fbjs "^3.0.2"
     invariant "^2.2.4"
 
+relay-test-utils@20.1.1:
+  version "20.1.1"
+  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-20.1.1.tgz#7dbb7cdd3439ad1278ee1ce217ebdfbe75e9568a"
+  integrity sha512-9E6+smojY43XmBi7un5l+8xWpqq1AgJtNEJZHDOLbdF8NIOzxI1n/HF2zZeGbqVQWjpvl/EyqegL6LLrIIJpcA==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    fbjs "^3.0.2"
+    invariant "^2.2.4"
+    relay-runtime "20.1.1"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"

--- a/rescript-relay-documentation/docs/testing.md
+++ b/rescript-relay-documentation/docs/testing.md
@@ -10,7 +10,7 @@ RescriptRelay provides a small set of helpers for rendering fragment components 
 
 ## Rendering fragment components with data
 
-Every fragment module exposes `Test.fromData`. It takes the generated fragment data type and returns something that can be passed anywhere that fragment's ref type is expected.
+Every non-inline fragment module exposes `Test.fromData`. It takes the generated fragment data type and returns something that can be passed anywhere that fragment's ref type is expected.
 
 This is useful when you want to render a fragment component directly in tests, Storybook, or local examples without wrapping it in a Relay environment and executing a query.
 

--- a/rescript-relay-documentation/docs/testing.md
+++ b/rescript-relay-documentation/docs/testing.md
@@ -1,0 +1,142 @@
+---
+id: testing
+title: Testing
+sidebar_label: Testing
+---
+
+## Testing
+
+RescriptRelay provides a small set of helpers for rendering fragment components with typed data, and for using Relay's mock environment with typed query variables and payloads.
+
+## Rendering fragment components with data
+
+Every fragment module exposes `Test.fromData`. It takes the generated fragment data type and returns something that can be passed anywhere that fragment's ref type is expected.
+
+This is useful when you want to render a fragment component directly in tests, Storybook, or local examples without wrapping it in a Relay environment and executing a query.
+
+```rescript
+module UserNameFragment = %relay(`
+  fragment UserName_user on User {
+    firstName
+    lastName
+  }
+`)
+
+@react.component
+let make = (~user) => {
+  let user = UserNameFragment.use(user)
+  <span> {React.string(user.firstName ++ " " ++ user.lastName)} </span>
+}
+
+let testElement = () =>
+  <UserName
+    user={UserNameFragment.Test.fromData({
+      firstName: "Ada",
+      lastName: "Lovelace",
+    })}
+  />
+```
+
+The value passed to `fromData` is fully typed from the fragment. If the fragment changes, ReScript will tell you which test data needs to change.
+
+Plural fragments use the same API, but take an array:
+
+```rescript
+module UsersFragment = %relay(`
+  fragment UsersList_users on User @relay(plural: true) {
+    id
+    firstName
+  }
+`)
+
+let testElement = () =>
+  <UsersList
+    users={UsersFragment.Test.fromData([
+      {id: "user-1", firstName: "Ada"},
+      {id: "user-2", firstName: "Grace"},
+    ])}
+  />
+```
+
+Nested fragment spreads work by building the nested fragment refs with their own `Test.fromData` helper:
+
+```rescript
+module AvatarFragment = %relay(`
+  fragment UserAvatar_user on User {
+    avatarUrl
+  }
+`)
+
+module UserFragment = %relay(`
+  fragment UserCard_user on User {
+    firstName
+    ...UserAvatar_user
+  }
+`)
+
+let testElement = () =>
+  <UserCard
+    user={UserFragment.Test.fromData({
+      firstName: "Ada",
+      fragmentRefs: AvatarFragment.Test.fromData({
+        avatarUrl: Some("https://example.com/avatar.png"),
+      }),
+    })}
+  />
+```
+
+These synthetic fragment refs are intended for mount-time test data. Do not switch the same mounted component from a synthetic ref to a real Relay ref, or from a real Relay ref to a synthetic ref. The implementation skips Relay's `useFragment` hook when synthetic data is present, so swapping modes in the same mounted component can violate React's hook ordering rules. Rendering separate components, separate tests, or remounting with a different React `key` is fine.
+
+## Relay mock environment helpers
+
+For tests that should exercise Relay's store and operation machinery, use Relay's mock environment. RescriptRelay exposes a binding to `createMockEnvironment`:
+
+```rescript
+let environment = RescriptRelay_Test.createMockEnvironment()
+```
+
+Install `relay-test-utils` in packages that use this helper:
+
+```bash
+yarn add --dev relay-test-utils
+```
+
+## Typed query mock helpers
+
+Queries annotated with both `@relay_test_operation` and `@raw_response_type` get a generated `Test` module:
+
+```rescript
+module Query = %relay(`
+  query UserCardTestQuery($id: ID!) @relay_test_operation @raw_response_type {
+    user(id: $id) {
+      id
+      firstName
+    }
+  }
+`)
+```
+
+That module exposes typed helpers for queueing the pending operation and resolving the most recent operation:
+
+```rescript
+let environment = RescriptRelay_Test.createMockEnvironment()
+
+Query.Test.queuePendingOperation(
+  ~environment,
+  ~variables={id: "user-1"},
+)
+
+Query.Test.resolveMostRecentOperation(
+  ~environment,
+  ~payload={
+    user: Some({
+      id: "user-1",
+      firstName: "Ada",
+    }),
+  },
+)
+```
+
+`queuePendingOperation` uses the query's generated variable type, and `resolveMostRecentOperation` uses the generated raw response type. This keeps query tests aligned with the operation shape Relay expects.
+
+The query helpers are only generated when both directives are present. `@relay_test_operation` makes the operation compatible with Relay's testing utilities, and `@raw_response_type` gives RescriptRelay the typed payload shape needed for `resolveMostRecentOperation`.

--- a/rescript-relay-documentation/sidebars.js
+++ b/rescript-relay-documentation/sidebars.js
@@ -32,6 +32,7 @@ module.exports = {
       "refetching-and-loading-more-data",
       "pagination",
       "variables",
+      "testing",
       "subscriptions",
       "enums",
       "unions",


### PR DESCRIPTION
## Summary

Adds typed testing helpers for ReScript Relay components and queries.

- Generates `Fragment.Test.fromData(...)` for fragment modules so tests and Storybook examples can render fragment components directly with typed fragment data.
- Adds synthetic fragment-ref runtime support in `Fragment.use` and `Fragment.useOpt`, including plural refs and nested fragment refs.
- Adds `RescriptRelay_Test.createMockEnvironment` plus query `Test` helpers for operations annotated with both `@relay_test_operation` and `@raw_response_type`.
- Adds dedicated testing-helper coverage, including synthetic refs, optional refs, plural refs, typed query resolution, and synthetic/real fragment refs rendered side by side.
- Documents the testing workflow and its mount-time synthetic-ref limitation.

## Validation

- `yarn build`
- `yarn jest __tests__/Test_testingHelpers-tests.js --runInBand`
- `yarn test --runInBand`
- `git diff --check`

Note: docs build was not run because `rescript-relay-documentation` does not currently have `node_modules` installed in this checkout (`docusaurus` is missing).