### PR TITLE
Fix traverse exiting early after custom-scalar array conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+- Fix `traverse` exiting after a custom-scalar field (single array-backed `c`, or `ca`), leaving subsequent fields on the same parent uncoerced. Surfaced as raw `null` for nullable response fields, raw ReScript values for unserialized variables, and (in nested input objects) silently skipped converters. Closes #582; extends #434's #407 fix so trailing fields are preserved.
+
 # 4.5.0
 
 - Add typed testing helpers for Relay tests:

--- a/packages/rescript-relay/__tests__/Test_arrayUnderlyingScalarSibling-tests.js
+++ b/packages/rescript-relay/__tests__/Test_arrayUnderlyingScalarSibling-tests.js
@@ -1,0 +1,45 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+
+const {
+  test_arrayUnderlyingScalarSibling,
+} = require("./Test_arrayUnderlyingScalarSibling.bs");
+
+// Integration repro for issue #407: when a custom scalar's runtime
+// representation is itself an array (here `Number = array<int>`), the
+// `c` branch in `traverse` (utils.js:134-138) is what fires — not `ca`.
+// That branch was added by PR #434 to close #407 but it terminated with
+// `return` instead of `continue`, so any sibling variable processed
+// after the array-backed scalar had its converter skipped. This test
+// declares `$number: Number!` before `$beforeDate: Datetime`, which
+// puts `number` first in the generated variables record and thus first
+// in the per-key iteration. With the bug, only `Number.serialize` would
+// run; with the fix in this PR, both `Number.serialize` and
+// `Datetime.serialize` run.
+describe("Array-backed custom scalar followed by another custom scalar (#407)", () => {
+  test("sibling Datetime variable is still serialized after array-backed Number", async () => {
+    const logSpy = jest.spyOn(console, "log");
+    queryMock.mockQuery({
+      name: "TestArrayUnderlyingScalarSiblingQuery",
+      variables: {
+        aaNumber: 6,
+        beforeDate: "1970-01-01T00:00:00.000Z",
+      },
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          friends: [],
+        },
+      },
+    });
+
+    t.render(test_arrayUnderlyingScalarSibling());
+
+    await t.screen.findByText("rendered");
+
+    expect(logSpy).toHaveBeenCalledWith("Number.serialize");
+    expect(logSpy).toHaveBeenCalledWith("Datetime.serialize");
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_arrayUnderlyingScalarSibling.res
+++ b/packages/rescript-relay/__tests__/Test_arrayUnderlyingScalarSibling.res
@@ -1,0 +1,51 @@
+// `Number` is a custom scalar whose ReScript representation is an array
+// (`type number = array<int>`). At wire-encode time `traverse`
+// (utils.js) hits the `c` branch at lines 134-138 — the one introduced
+// by PR #434 to close issue #407 — because the value is an array even
+// though the schema-level type is a single scalar.
+//
+// relay-compiler sorts the generated `variables` record fields
+// alphabetically, so this test prefixes the array-backed variable with
+// `aa` to force it to be iterated before `beforeDate`. Without the fix
+// in this PR (#631), the `aaNumber` branch returns early and
+// `Datetime.serialize` is never called for `beforeDate`.
+module Query = %relay(`
+  query TestArrayUnderlyingScalarSiblingQuery(
+    $aaNumber: Number!
+    $beforeDate: Datetime
+  ) {
+    loggedInUser {
+      friends(number: $aaNumber, beforeDate: $beforeDate) {
+        id
+      }
+    }
+  }
+`)
+
+module Test = {
+  @react.component
+  let make = () => {
+    let _ = Query.use(
+      ~variables={
+        aaNumber: [1, 2, 3],
+        beforeDate: Date.fromTime(0.),
+      },
+    )
+
+    React.string("rendered")
+  }
+}
+
+@live
+let test_arrayUnderlyingScalarSibling = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery)
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make()),
+  )
+
+  <TestProviders.Wrapper environment>
+    <Test />
+  </TestProviders.Wrapper>
+}

--- a/packages/rescript-relay/__tests__/Test_customScalarAfterCustomScalarArray-tests.js
+++ b/packages/rescript-relay/__tests__/Test_customScalarAfterCustomScalarArray-tests.js
@@ -1,0 +1,38 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+
+const {
+  test_customScalarAfterCustomScalarArray,
+} = require("./Test_customScalarAfterCustomScalarArray.bs");
+
+// Read-side analog of #582 / direct read-side analog of #631 (this PR):
+// after a `[CustomScalar!]` field on the response is processed by the
+// `ca` branch in `traverse` (utils.js), subsequent fields in the same
+// selection set are leaked through `Object.assign` untouched. For a
+// `c` custom scalar like `createdAt: Datetime!`, that means the user
+// receives the raw wire string instead of a parsed `Date.t`.
+//
+// On master the rendered text never appears: `Date.getTime` on a raw
+// string throws (no `.getTime` method on strings). On the fix, the
+// timestamp renders.
+describe("Custom scalar following a custom-scalar array (#582 read / #631)", () => {
+  test("createdAt is parsed when intStrings precedes it in the selection set", async () => {
+    const expected = new Date(2020, 1, 1, 0, 0, 0, 0);
+    queryMock.mockQuery({
+      name: "TestCustomScalarAfterCustomScalarArrayQuery",
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          intStrings: ["1", "2"],
+          createdAt: expected.toJSON(),
+        },
+      },
+    });
+
+    t.render(test_customScalarAfterCustomScalarArray());
+
+    await t.screen.findByText("createdAt: " + expected.getTime().toString());
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_customScalarAfterCustomScalarArray.res
+++ b/packages/rescript-relay/__tests__/Test_customScalarAfterCustomScalarArray.res
@@ -1,0 +1,42 @@
+module Query = %relay(`
+  query TestCustomScalarAfterCustomScalarArrayQuery {
+    loggedInUser {
+      intStrings
+      createdAt
+    }
+  }
+`)
+
+module Test = {
+  @react.component
+  let make = () => {
+    let query = Query.use(~variables=())
+
+    // `createdAt` is `Datetime!` (a `c` custom scalar). The conversion path
+    // through `Datetime.parse` turns the wire string into a `Date.t`.
+    // When the bug fires (`ca` for `intStrings` exits the loop early),
+    // `Datetime.parse` is never called and `createdAt` reaches us as the
+    // raw wire string. Calling `Date.getTime` on a string crashes; calling
+    // it on a Date returns a number. The text we render either equals the
+    // expected timestamp (parsed) or never appears (unparsed).
+    <div>
+      {React.string(
+        "createdAt: " ++ query.loggedInUser.createdAt->Date.getTime->Float.toString,
+      )}
+    </div>
+  }
+}
+
+@live
+let test_customScalarAfterCustomScalarArray = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery)
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make()),
+  )
+
+  <TestProviders.Wrapper environment>
+    <Test />
+  </TestProviders.Wrapper>
+}

--- a/packages/rescript-relay/__tests__/Test_nullableScalarsAfterCustomScalarArray-tests.js
+++ b/packages/rescript-relay/__tests__/Test_nullableScalarsAfterCustomScalarArray-tests.js
@@ -1,0 +1,47 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+
+const {
+  test_nullableScalarsAfterCustomScalarArray,
+} = require("./Test_nullableScalarsAfterCustomScalarArray.bs");
+
+// Nullable scalars selected after a `[CustomScalar!]` field whose runtime value
+// is a non-null array must still decode to `None` when the wire data is `null`.
+//
+// The custom-scalar-array branch in `traverse` (utils.js) is the conversion path
+// for fields like `intStrings: [IntString!]`. When that branch fires, every
+// subsequent field in the same record's selection set goes through the rest of
+// the per-key loop body. Their `null` values must therefore reach the
+// null-coercion that turns `null` into the configured nullable representation
+// (`undefined` for fragments). If that coercion is skipped, ReScript reads the
+// raw `null` as `Some(null)` and pattern matches take the wrong branch.
+describe("Nullable scalars following a custom-scalar array", () => {
+  test("nullable scalars selected after a [CustomScalar!] field decode to None when null", async () => {
+    queryMock.mockQuery({
+      name: "TestNullableScalarsAfterCustomScalarArrayQuery",
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          intStrings: ["1", "2"],
+          avatarUrl: null,
+          isOnline: null,
+          private: null,
+          onlineStatus: null,
+        },
+      },
+    });
+
+    t.render(test_nullableScalarsAfterCustomScalarArray());
+
+    // The `private` label runs `Type.classify` (via Obj.magic + Null.toOption)
+    // on the option's payload, so when the bug fires the rendered text is
+    // literally `private=Some(null)` — the smoking gun. The fixed behaviour
+    // is `private=None`.
+    await t.screen.findByText("avatarUrl=None");
+    await t.screen.findByText("isOnline=None");
+    await t.screen.findByText("private=None");
+    await t.screen.findByText("onlineStatus=None");
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_nullableScalarsAfterCustomScalarArray.res
+++ b/packages/rescript-relay/__tests__/Test_nullableScalarsAfterCustomScalarArray.res
@@ -1,0 +1,75 @@
+module Query = %relay(`
+  query TestNullableScalarsAfterCustomScalarArrayQuery {
+    loggedInUser {
+      id
+      intStrings
+      avatarUrl
+      isOnline
+      private
+      onlineStatus
+    }
+  }
+`)
+
+module Test = {
+  @react.component
+  let make = () => {
+    let query = {
+      Query.use(~variables=())
+    }
+    let user = query.loggedInUser
+
+    let avatarUrlLabel = switch user.avatarUrl {
+    | None => "avatarUrl=None"
+    | Some(_) => "avatarUrl=Some(_)"
+    }
+    let isOnlineLabel = switch user.isOnline {
+    | None => "isOnline=None"
+    | Some(_) => "isOnline=Some(_)"
+    }
+    // For `private` we don't just report which option branch we hit — we use
+    // `Type.classify` on the inner value to spell out what ReScript sees at
+    // runtime. When the bug fires, the option's payload is the raw JS `null`
+    // and this label renders `private=Some(null)`. That's the smoking gun:
+    // the generated type says `option<bool>` but the value isn't really a
+    // `bool` and isn't really `None`.
+    let privateLabel = switch user.private_ {
+    | None => "private=None"
+    | Some(v) =>
+      // The generated type says `option<bool>`, so `v: bool`. Reach past
+      // the type with `Obj.magic` and check what the runtime value
+      // actually is — when the bug fires it's the raw JS `null`, not a
+      // boolean.
+      let kind = switch (Obj.magic(v) :> Null.t<bool>)->Null.toOption {
+      | None => "null"
+      | Some(_) => "bool"
+      }
+      `private=Some(${kind})`
+    }
+    let onlineStatusLabel = switch user.onlineStatus {
+    | None => "onlineStatus=None"
+    | Some(_) => "onlineStatus=Some(_)"
+    }
+
+    <>
+      <div> {avatarUrlLabel->React.string} </div>
+      <div> {isOnlineLabel->React.string} </div>
+      <div> {privateLabel->React.string} </div>
+      <div> {onlineStatusLabel->React.string} </div>
+    </>
+  }
+}
+
+@live
+let test_nullableScalarsAfterCustomScalarArray = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery)
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make()),
+  )
+
+  <TestProviders.Wrapper environment>
+    <Test />
+  </TestProviders.Wrapper>
+}

--- a/packages/rescript-relay/__tests__/Test_serializeMultipleCustomScalars-tests.js
+++ b/packages/rescript-relay/__tests__/Test_serializeMultipleCustomScalars-tests.js
@@ -1,0 +1,49 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+const ReactTestUtils = require("react-dom/test-utils");
+
+const {
+  test_serializeMultipleCustomScalars,
+} = require("./Test_serializeMultipleCustomScalars.bs");
+
+// Integration repro for issue #582 (ValdemarGr): adding a `[CustomScalar]`
+// field next to another `CustomScalar` field in an input object causes the
+// second scalar's serializer to be skipped — the wire receives the raw
+// ReScript value instead of the serialized form. Same root cause as the
+// bug in this PR (#631): the custom-scalar-array branch in
+// `traverse` (utils.js) exits the per-key loop with `return` instead of
+// `continue`, so every subsequent field is leaked through
+// `Object.assign` untouched.
+//
+// On master both serializers' log lines should NOT both fire — only
+// `ObjectScalar1.serialize` runs (the one in the `os1s` array) and
+// `ObjectScalar2.serialize` is skipped. With the fix in this PR, both
+// run.
+describe("Serialize multiple custom scalars (#582)", () => {
+  test("ca followed by c in input — both serializers run", async () => {
+    const logSpy = jest.spyOn(console, "log");
+    t.render(test_serializeMultipleCustomScalars());
+
+    const resolveQuery = queryMock.mockQueryWithControlledResolution({
+      name: "TestSerializeMultipleCustomScalarsMutation",
+      data: {
+        serializeMultipleCustomScalars: true,
+      },
+    });
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(t.screen.getByText("Fire mutation"));
+    });
+
+    await t.screen.findByText("Mutating...");
+
+    ReactTestUtils.act(() => {
+      resolveQuery();
+    });
+
+    expect(logSpy).toHaveBeenCalledWith("ObjectScalar1.serialize");
+    expect(logSpy).toHaveBeenCalledWith("ObjectScalar2.serialize");
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_serializeMultipleCustomScalars.res
+++ b/packages/rescript-relay/__tests__/Test_serializeMultipleCustomScalars.res
@@ -1,0 +1,47 @@
+module Mutation = %relay(`
+    mutation TestSerializeMultipleCustomScalarsMutation($input: SerializeMultipleCustomScalars!) {
+      serializeMultipleCustomScalars(input: $input)
+    }
+`)
+
+module Test = {
+  @react.component
+  let make = () => {
+    let (mutate, isMutating) = Mutation.use()
+
+    <div>
+      <button
+        onClick={_ => {
+          mutate(
+            ~variables={
+              input: {
+                os1s: [{a: "x"}],
+                os2: {a: "y"},
+              },
+            },
+          )->ignore
+        }}>
+        {React.string("Fire mutation")}
+      </button>
+      {if isMutating {
+        React.string("Mutating...")
+      } else {
+        React.null
+      }}
+    </div>
+  }
+}
+
+@live
+let test_serializeMultipleCustomScalars = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery)
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make()),
+  )
+
+  <TestProviders.Wrapper environment>
+    <Test />
+  </TestProviders.Wrapper>
+}

--- a/packages/rescript-relay/__tests__/TestsUtils.res
+++ b/packages/rescript-relay/__tests__/TestsUtils.res
@@ -10,11 +10,11 @@ module Datetime = {
     | None => throw(Malformed_date)
     | Some(dateStr) => dateStr->Date.fromString
     }
-  let serialize = t =>
-    t
-    ->Date.toJSON
-    ->Option.getOr("-")
-    ->JSON.Encode.string
+  let serialize = t => {
+    // This log is used for testing purposes - do not remove
+    Console.log("Datetime.serialize")
+    t->Date.toJSON->Option.getOr("-")->JSON.Encode.string
+  }
 }
 
 module IntString = {
@@ -32,11 +32,54 @@ type number = array<int>
 
 module Number = {
   type t = number
-  let serialize = t => JSON.Encode.float(Float.fromInt(t->Array.reduce(0, (x, y) => y + x)))
+  let serialize = t => {
+    // This log is used for testing purposes - do not remove
+    Console.log("Number.serialize")
+    JSON.Encode.float(Float.fromInt(t->Array.reduce(0, (x, y) => y + x)))
+  }
 
   let parse = t =>
     switch t->JSON.Decode.float {
     | None => throw(Malformed_number)
     | Some(_) => []
     }
+}
+
+type objectScalarPayload = {
+  a: string,
+  b?: string,
+  c?: string,
+}
+
+// Custom-scalar shapes used by the regression tests for issues #582 and
+// #631. The serializers log so a Jest harness can assert which converters
+// actually ran for a given operation — the bug in those issues was that
+// converters silently DIDN'T run for fields placed after a custom-scalar
+// array in the same selection set.
+module ObjectScalar1 = {
+  type t = objectScalarPayload
+  let serialize = (_: t) => {
+    // This log is used for testing purposes - do not remove
+    Console.log("ObjectScalar1.serialize")
+    JSON.Encode.string("serialized1")
+  }
+  let parse = (_: JSON.t): t => {
+    // This log is used for testing purposes - do not remove
+    Console.log("ObjectScalar1.parse")
+    {a: "parsed1"}
+  }
+}
+
+module ObjectScalar2 = {
+  type t = objectScalarPayload
+  let serialize = (_: t) => {
+    // This log is used for testing purposes - do not remove
+    Console.log("ObjectScalar2.serialize")
+    JSON.Encode.string("serialized2")
+  }
+  let parse = (_: JSON.t): t => {
+    // This log is used for testing purposes - do not remove
+    Console.log("ObjectScalar2.parse")
+    {a: "parsed2"}
+  }
 }

--- a/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
@@ -248,3 +248,15 @@ and input_Location_nullable =
 | @as("byAddress") ByAddress(input_ByAddress_nullable)
 | @as("byLoc") ByLoc(input_ByLoc_nullable)
 | @as("byId") ById(string)
+
+@live
+and input_SerializeMultipleCustomScalars = {
+  os1s: array<TestsUtils.ObjectScalar1.t>,
+  os2?: TestsUtils.ObjectScalar2.t,
+}
+
+@live
+and input_SerializeMultipleCustomScalars_nullable = {
+  os1s: array<TestsUtils.ObjectScalar1.t>,
+  os2?: Null.t<TestsUtils.ObjectScalar2.t>,
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestArrayUnderlyingScalarSiblingQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestArrayUnderlyingScalarSiblingQuery_graphql.res
@@ -1,0 +1,241 @@
+/* @sourceLoc Test_arrayUnderlyingScalarSibling.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type rec response_loggedInUser_friends = {
+    @live id: string,
+  }
+  and response_loggedInUser = {
+    friends: array<response_loggedInUser_friends>,
+  }
+  type response = {
+    loggedInUser: response_loggedInUser,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = {
+    aaNumber: TestsUtils.Number.t,
+    beforeDate?: TestsUtils.Datetime.t,
+  }
+  @live
+  type refetchVariables = {
+    aaNumber?: TestsUtils.Number.t,
+    beforeDate?: option<TestsUtils.Datetime.t>,
+  }
+  @live let makeRefetchVariables = (
+    ~aaNumber=?,
+    ~beforeDate=?,
+  ): refetchVariables => {
+    aaNumber: ?aaNumber,
+    beforeDate: ?beforeDate
+  }
+
+}
+
+
+type queryRef
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"beforeDate":{"c":"TestsUtils.Datetime"},"aaNumber":{"c":"TestsUtils.Number"}}}`
+  )
+  @live
+  let variablesConverterMap = {
+    "TestsUtils.Number": TestsUtils.Number.serialize,
+    "TestsUtils.Datetime": TestsUtils.Datetime.serialize,
+  }
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "aaNumber"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "beforeDate"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "beforeDate",
+      "variableName": "beforeDate"
+    },
+    {
+      "kind": "Variable",
+      "name": "number",
+      "variableName": "aaNumber"
+    }
+  ],
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "friends",
+  "plural": true,
+  "selections": [
+    (v1/*: any*/)
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestArrayUnderlyingScalarSiblingQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TestArrayUnderlyingScalarSiblingQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7b7d61827814163d88d94f55d085b34c",
+    "id": null,
+    "metadata": {},
+    "name": "TestArrayUnderlyingScalarSiblingQuery",
+    "operationKind": "query",
+    "text": "query TestArrayUnderlyingScalarSiblingQuery(\n  $aaNumber: Number!\n  $beforeDate: Datetime\n) {\n  loggedInUser {\n    friends(number: $aaNumber, beforeDate: $beforeDate) {\n      id\n    }\n    id\n  }\n}\n"
+  }
+};
+})() `)
+
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelayReact.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Promise.make((resolve, _reject) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok())))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestCustomScalarAfterCustomScalarArrayQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestCustomScalarAfterCustomScalarArrayQuery_graphql.res
@@ -1,0 +1,209 @@
+/* @sourceLoc Test_customScalarAfterCustomScalarArray.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type rec response_loggedInUser = {
+    createdAt: TestsUtils.Datetime.t,
+    intStrings: option<array<TestsUtils.IntString.t>>,
+  }
+  type response = {
+    loggedInUser: response_loggedInUser,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = unit
+  @live
+  type refetchVariables = unit
+  @live let makeRefetchVariables = () => ()
+}
+
+
+type queryRef
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"loggedInUser_intStrings":{"ca":"TestsUtils.IntString"},"loggedInUser_createdAt":{"c":"TestsUtils.Datetime"}}}`
+  )
+  @live
+  let wrapResponseConverterMap = {
+    "TestsUtils.Datetime": TestsUtils.Datetime.serialize,
+    "TestsUtils.IntString": TestsUtils.IntString.serialize,
+  }
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"loggedInUser_intStrings":{"ca":"TestsUtils.IntString"},"loggedInUser_createdAt":{"c":"TestsUtils.Datetime"}}}`
+  )
+  @live
+  let responseConverterMap = {
+    "TestsUtils.Datetime": TestsUtils.Datetime.parse,
+    "TestsUtils.IntString": TestsUtils.IntString.parse,
+  }
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "intStrings",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestCustomScalarAfterCustomScalarArrayQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TestCustomScalarAfterCustomScalarArrayQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "03e0f99cd2c31378f6fca68d99bcb377",
+    "id": null,
+    "metadata": {},
+    "name": "TestCustomScalarAfterCustomScalarArrayQuery",
+    "operationKind": "query",
+    "text": "query TestCustomScalarAfterCustomScalarArrayQuery {\n  loggedInUser {\n    intStrings\n    createdAt\n    id\n  }\n}\n"
+  }
+};
+})() `)
+
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelayReact.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Promise.make((resolve, _reject) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok())))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestNullableScalarsAfterCustomScalarArrayQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNullableScalarsAfterCustomScalarArrayQuery_graphql.res
@@ -1,0 +1,232 @@
+/* @sourceLoc Test_nullableScalarsAfterCustomScalarArray.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  type rec response_loggedInUser = {
+    avatarUrl: option<string>,
+    @live id: string,
+    intStrings: option<array<TestsUtils.IntString.t>>,
+    isOnline: option<bool>,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+    @as("private") private_: option<bool>,
+  }
+  type response = {
+    loggedInUser: response_loggedInUser,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = unit
+  @live
+  type refetchVariables = unit
+  @live let makeRefetchVariables = () => ()
+}
+
+
+type queryRef
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"loggedInUser_intStrings":{"ca":"TestsUtils.IntString"}}}`
+  )
+  @live
+  let wrapResponseConverterMap = {
+    "TestsUtils.IntString": TestsUtils.IntString.serialize,
+  }
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{"__root":{"loggedInUser_intStrings":{"ca":"TestsUtils.IntString"}}}`
+  )
+  @live
+  let responseConverterMap = {
+    "TestsUtils.IntString": TestsUtils.IntString.parse,
+  }
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+  @live
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
+  @live
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
+  @live
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
+    onlineStatus_decode(Obj.magic(str))
+  }
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "User",
+    "kind": "LinkedField",
+    "name": "loggedInUser",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "intStrings",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "avatarUrl",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isOnline",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "private",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "onlineStatus",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestNullableScalarsAfterCustomScalarArrayQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TestNullableScalarsAfterCustomScalarArrayQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "060acca966292ed2c3be1b6610260bf1",
+    "id": null,
+    "metadata": {},
+    "name": "TestNullableScalarsAfterCustomScalarArrayQuery",
+    "operationKind": "query",
+    "text": "query TestNullableScalarsAfterCustomScalarArrayQuery {\n  loggedInUser {\n    id\n    intStrings\n    avatarUrl\n    isOnline\n    private\n    onlineStatus\n  }\n}\n"
+  }
+};
+})() `)
+
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelayReact.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Promise.make((resolve, _reject) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok())))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestSerializeMultipleCustomScalarsMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSerializeMultipleCustomScalarsMutation_graphql.res
@@ -1,0 +1,131 @@
+/* @sourceLoc Test_serializeMultipleCustomScalars.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@warning("-30")
+
+  @live type serializeMultipleCustomScalars = RelaySchemaAssets_graphql.input_SerializeMultipleCustomScalars
+  @live
+  type response = {
+    serializeMultipleCustomScalars: option<bool>,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = {
+    input: serializeMultipleCustomScalars,
+  }
+}
+
+module Internal = {
+  @live
+  let variablesConverter: dict<dict<dict<string>>> = %raw(
+    json`{"serializeMultipleCustomScalars":{"os2":{"c":"TestsUtils.ObjectScalar2"},"os1s":{"ca":"TestsUtils.ObjectScalar1"}},"__root":{"input":{"r":"serializeMultipleCustomScalars"}}}`
+  )
+  @live
+  let variablesConverterMap = {
+    "TestsUtils.ObjectScalar1": TestsUtils.ObjectScalar1.serialize,
+    "TestsUtils.ObjectScalar2": TestsUtils.ObjectScalar2.serialize,
+  }
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    None
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: dict<dict<dict<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    None
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+module Utils = {
+  @@warning("-33")
+  open Types
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.mutationNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "kind": "ScalarField",
+    "name": "serializeMultipleCustomScalars",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestSerializeMultipleCustomScalarsMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TestSerializeMultipleCustomScalarsMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "d86ec951867af25200a3ad2b01b9f1d9",
+    "id": null,
+    "metadata": {},
+    "name": "TestSerializeMultipleCustomScalarsMutation",
+    "operationKind": "mutation",
+    "text": "mutation TestSerializeMultipleCustomScalarsMutation(\n  $input: SerializeMultipleCustomScalars!\n) {\n  serializeMultipleCustomScalars(input: $input)\n}\n"
+  }
+};
+})() `)
+
+

--- a/packages/rescript-relay/__tests__/schema.graphql
+++ b/packages/rescript-relay/__tests__/schema.graphql
@@ -258,6 +258,9 @@ type Mutation {
   serializeCustomScalarArray(
     input: [IntString!]!
   ): SerializeCustomScalarArrayPayload
+  serializeMultipleCustomScalars(
+    input: SerializeMultipleCustomScalars!
+  ): Boolean
 }
 
 type Subscription {
@@ -276,4 +279,12 @@ input Location @oneOf {
   byAddress: ByAddress
   byLoc: ByLoc
   byId: ID
+}
+
+scalar ObjectScalar1
+scalar ObjectScalar2
+
+input SerializeMultipleCustomScalars {
+  os1s: [ObjectScalar1!]!
+  os2: ObjectScalar2
 }

--- a/packages/rescript-relay/__tests__/utils-tests.js
+++ b/packages/rescript-relay/__tests__/utils-tests.js
@@ -878,4 +878,384 @@ describe("conversion", () => {
       });
     });
   });
+
+  // `c` and `ca` are emitted identically for all four GraphQL array
+  // nullability variants (`[T!]!` / `[T!]` / `[T]!` / `[T]`) — only
+  // `found_in_array` (relay-typegen/src/rescript.rs) is encoded. The
+  // cells below cover each wire-payload shape `traverse` may see.
+  describe("custom scalar instructions (c, ca)", () => {
+    const SCALAR = "TestsUtils.FakeScalar";
+    // `parse` is shaped so an accidental `parse(null)` shows up in the
+    // assertion as `"parsed:null"` rather than something innocuous.
+    const parse = (v) => `parsed:${String(v)}`;
+    const serialize = (v) => ({ serialized: v });
+    const someNoneMarker = { BS_PRIVATE_NESTED_SOME_NONE: 0 };
+
+    describe("c — single custom scalar, read (nullableValue: undefined)", () => {
+      test("present value runs through `parse` and is the only sibling untouched", () => {
+        expect(
+          traverser(
+            { x: "raw" },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({ x: "parsed:raw" });
+      });
+
+      test("null wire value becomes `undefined` and `parse` is never called", () => {
+        const spy = jest.fn(parse);
+        expect(
+          traverser(
+            { x: null },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: spy },
+            undefined
+          )
+        ).toEqual({ x: undefined });
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test("BS_PRIVATE_NESTED_SOME_NONE marker passes through unchanged", () => {
+        const spy = jest.fn(parse);
+        const out = traverser(
+          { x: someNoneMarker },
+          { __root: { x: { c: SCALAR } } },
+          { [SCALAR]: spy },
+          undefined
+        );
+        expect(out.x).toBe(someNoneMarker);
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test("c sibling with a null neighbour — null neighbour decodes to undefined", () => {
+        expect(
+          traverser(
+            { x: "raw", y: null },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({ x: "parsed:raw", y: undefined });
+      });
+    });
+
+    describe("c — single custom scalar, write (nullableValue: null)", () => {
+      test("present value runs through `serialize`", () => {
+        expect(
+          traverser(
+            { x: 7 },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({ x: { serialized: 7 } });
+      });
+
+      test("null encodes to null and `serialize` is never called", () => {
+        const spy = jest.fn(serialize);
+        expect(
+          traverser(
+            { x: null },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: spy },
+            null
+          )
+        ).toEqual({ x: null });
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test("c sibling followed by another c — both converters run", () => {
+        const out = traverser(
+          { a: 1, b: 2 },
+          { __root: { a: { c: SCALAR }, b: { c: SCALAR } } },
+          { [SCALAR]: serialize },
+          null
+        );
+        expect(out).toEqual({
+          a: { serialized: 1 },
+          b: { serialized: 2 },
+        });
+      });
+    });
+
+    describe("ca — custom scalar array, read (nullableValue: undefined)", () => {
+      test("[T!]! / [T!] — non-null elements, present array: parse runs per element", () => {
+        expect(
+          traverser(
+            { xs: ["a", "b"] },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({ xs: ["parsed:a", "parsed:b"] });
+      });
+
+      test("[T!]! / [T]! — empty array stays empty, parse is never called", () => {
+        const spy = jest.fn(parse);
+        expect(
+          traverser(
+            { xs: [] },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: spy },
+            undefined
+          )
+        ).toEqual({ xs: [] });
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test("[T!] / [T] — array-level null decodes to undefined", () => {
+        const spy = jest.fn(parse);
+        expect(
+          traverser(
+            { xs: null },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: spy },
+            undefined
+          )
+        ).toEqual({ xs: undefined });
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test("[T]! / [T] — array contains a null element: CURRENT BEHAVIOR calls parse(null)", () => {
+        // Locks in current behavior. utils.js:109-113 maps `converter`
+        // over every element with no per-element null check, so a wire
+        // null reaches user code as `parse(null)`. A future fix should
+        // produce `[parse("a"), undefined, parse("b")]` — out of scope
+        // for this PR.
+        expect(
+          traverser(
+            { xs: ["a", null, "b"] },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({ xs: ["parsed:a", "parsed:null", "parsed:b"] });
+      });
+
+      test("BS_PRIVATE_NESTED_SOME_NONE on a ca field passes through unchanged", () => {
+        const spy = jest.fn(parse);
+        const out = traverser(
+          { xs: someNoneMarker },
+          { __root: { xs: { ca: SCALAR } } },
+          { [SCALAR]: spy },
+          undefined
+        );
+        expect(out.xs).toBe(someNoneMarker);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("ca — custom scalar array, write (nullableValue: null)", () => {
+      test("[T!]! / [T!] — present array: serialize runs per element", () => {
+        expect(
+          traverser(
+            { xs: [10, 20] },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({
+          xs: [{ serialized: 10 }, { serialized: 20 }],
+        });
+      });
+
+      test("[T!] / [T] — null array encodes to null, serialize never called", () => {
+        const spy = jest.fn(serialize);
+        expect(
+          traverser(
+            { xs: null },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: spy },
+            null
+          )
+        ).toEqual({ xs: null });
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      test("[T]! / [T] — array contains null element: CURRENT BEHAVIOR calls serialize(null)", () => {
+        // Symmetric to the read-side cell of the same name. Out of
+        // scope for this PR; correct output would be
+        // `[serialize(10), null, serialize(30)]`.
+        expect(
+          traverser(
+            { xs: [10, null, 30] },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({
+          xs: [
+            { serialized: 10 },
+            { serialized: null },
+            { serialized: 30 },
+          ],
+        });
+      });
+    });
+
+    describe("regression #631 — `ca` followed by null sibling", () => {
+      test("read — null sibling decodes to undefined", () => {
+        expect(
+          traverser(
+            { xs: ["a"], q: null },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({ xs: ["parsed:a"], q: undefined });
+      });
+
+      test("write — null sibling encodes to null", () => {
+        expect(
+          traverser(
+            { xs: [1], q: null },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({ xs: [{ serialized: 1 }], q: null });
+      });
+    });
+
+    describe("regression #582 — `ca` followed by another `c`", () => {
+      test("write — both converters run", () => {
+        expect(
+          traverser(
+            { xs: [1], y: 2 },
+            { __root: { xs: { ca: SCALAR }, y: { c: SCALAR } } },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({
+          xs: [{ serialized: 1 }],
+          y: { serialized: 2 },
+        });
+      });
+
+      test("read — both converters run", () => {
+        expect(
+          traverser(
+            { xs: ["a"], y: "b" },
+            { __root: { xs: { ca: SCALAR }, y: { c: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({
+          xs: ["parsed:a"],
+          y: "parsed:b",
+        });
+      });
+    });
+
+    describe("regression #407 — single `c` whose underlying type is an array", () => {
+      // GraphQL type is a single scalar but the ReScript representation
+      // is an array (e.g. `Number = array<int>`). Hits the
+      // `shouldConvertCustomField && Array.isArray(...)` branch at
+      // utils.js:134-138 — not `ca`.
+      test("read — converter receives the whole array as one argument, traversal continues", () => {
+        const wholeArrayConverter = (arr) =>
+          Array.isArray(arr) ? `arr:${arr.length}` : `not-arr:${String(arr)}`;
+        expect(
+          traverser(
+            { x: [1, 2, 3], q: null },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: wholeArrayConverter },
+            undefined
+          )
+        ).toEqual({ x: "arr:3", q: undefined });
+      });
+
+      test("write — converter receives the whole array as one argument, traversal continues", () => {
+        const wholeArrayConverter = (arr) =>
+          Array.isArray(arr) ? arr.reduce((a, b) => a + b, 0) : -1;
+        expect(
+          traverser(
+            { x: [1, 2, 3], q: null },
+            { __root: { x: { c: SCALAR } } },
+            { [SCALAR]: wholeArrayConverter },
+            null
+          )
+        ).toEqual({ x: 6, q: null });
+      });
+    });
+
+    describe("sequencing — `ca` and other fields in the same selection set", () => {
+      test("two `ca` fields in a row — both arrays are converted", () => {
+        expect(
+          traverser(
+            { as: [1, 2], bs: [10, 20] },
+            { __root: { as: { ca: SCALAR }, bs: { ca: SCALAR } } },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({
+          as: [{ serialized: 1 }, { serialized: 2 }],
+          bs: [{ serialized: 10 }, { serialized: 20 }],
+        });
+      });
+
+      test("`ca` followed by a nested object whose fields need conversion — recursive descent still runs", () => {
+        expect(
+          traverser(
+            { xs: [1], inner: { y: 2 } },
+            {
+              __root: {
+                xs: { ca: SCALAR },
+                inner_y: { c: SCALAR },
+              },
+            },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({
+          xs: [{ serialized: 1 }],
+          inner: { y: { serialized: 2 } },
+        });
+      });
+
+      test("null sibling BEFORE `ca` — positive control, no bug to trigger here", () => {
+        // Documents that the bug fixed by this PR was order-sensitive:
+        // it only fired when `ca` came BEFORE other fields, because the
+        // early-`return` skipped the rest of the loop. With the null
+        // sibling first, it's coerced normally and `ca` then runs.
+        expect(
+          traverser(
+            { q: null, xs: ["a"] },
+            { __root: { xs: { ca: SCALAR } } },
+            { [SCALAR]: parse },
+            undefined
+          )
+        ).toEqual({ q: undefined, xs: ["parsed:a"] });
+      });
+    });
+
+    describe("`ca` inside a nested input object", () => {
+      test("ca field followed by plain fields inside an `r` record stays intact", () => {
+        expect(
+          traverser(
+            {
+              input: {
+                ids: [1, 2, 3],
+                take: 1,
+                skip: 0,
+              },
+            },
+            {
+              __root: { input: { r: "searchInput" } },
+              searchInput: { ids: { ca: SCALAR } },
+            },
+            { [SCALAR]: serialize },
+            null
+          )
+        ).toEqual({
+          input: {
+            ids: [{ serialized: 1 }, { serialized: 2 }, { serialized: 3 }],
+            take: 1,
+            skip: 0,
+          },
+        });
+      });
+    });
+  });
 });

--- a/packages/rescript-relay/relay.config.js
+++ b/packages/rescript-relay/relay.config.js
@@ -13,6 +13,8 @@ module.exports = {
     IntString: "TestsUtils.IntString",
     JSON: "JSON.t",
     Number: "TestsUtils.Number",
+    ObjectScalar1: "TestsUtils.ObjectScalar1",
+    ObjectScalar2: "TestsUtils.ObjectScalar2",
   },
   persistConfig: PERSISTING
     ? {

--- a/packages/rescript-relay/src/utils.js
+++ b/packages/rescript-relay/src/utils.js
@@ -109,7 +109,7 @@ function traverse(
     if (shouldConvertCustomFieldArray && Array.isArray(currentObj[key])) {
       newObj = getNewObj(newObj, currentObj);
       newObj[key] = currentObj[key].map(converters[instructions["ca"]]);
-      return newObj;
+      continue;
     }
 
     var shouldBlockTraversal = typeof instructions["b"] === "string";
@@ -134,7 +134,7 @@ function traverse(
     if (shouldConvertCustomField && Array.isArray(currentObj[key])) {
       newObj = getNewObj(newObj, currentObj);
       newObj[key] = converters[instructions["c"]](originalValue);
-      return newObj;
+      continue;
     }
 
     if (Array.isArray(currentObj[key])) {


### PR DESCRIPTION
## Summary
We had a bug in a project of mine where some of our custom scalars were coming back as Some(null) and breaking our frontend. The below is from a session with claude code where it isolated the issue. I then worked with LLM to get the repo and the toolchain for rescript-relay running running locally, run all the tests (including ci), build a breaking test in line with repo conventions, then provide a patch that fixes the error.

Anyway, first time pull-requester long-time-user and thanks to the maintainers for all the work they do. Below from the maw of the machine:

================

  `traverse` in `packages/rescript-relay/src/utils.js` exits the loop with `return newObj` after processing a
  `[CustomScalar!]` field, instead of moving on to the next key with `continue`. Every key that follows in the same
  record's selection set is then copied through unchanged via the shallow `Object.assign` done by `getNewObj`,
  bypassing the null-coercion at the top of the loop. ReScript reads the leaked raw `null` as `Some(null)` instead of
  `None`.

  ## Root Cause

  Two `return newObj;` statements inside the per-key `for (var key in currentObj)` loop should be `continue;`:

  - line 112 — `shouldConvertCustomFieldArray && Array.isArray(...)` branch (instruction `"ca"`, e.g. `[IntString!]`).
  - line 137 — `shouldConvertCustomField && Array.isArray(...)` branch (instruction `"c"` whose value is unexpectedly
  an array).

  Both blocks already write the converted value to `newObj[key]` before the exit. The leading comment on each ("Ensures
   we don't accidentally move into the array when we're not supposed to") matches the intent of skipping the remaining
  branches for the current key, i.e. `continue`. `return` exits the whole function and skips every later key.

  The lines 76-79 null-coercion (`if (currentObj[key] == null) { newObj[key] = nullableValue; continue; }`) — which
  turns `null` into `undefined` for fragment reads — never runs for any key that comes after the custom-scalar-array
  field in the selection set.

  ## Changes

  - `packages/rescript-relay/src/utils.js`: two-line fix.
  - `packages/rescript-relay/__tests__/Test_nullableScalarsAfterCustomScalarArray.res` + jest harness: regression test
  that selects `intStrings` followed by nullable `avatarUrl`, `isOnline`, `private`, `onlineStatus` on `loggedInUser`.
  The `private` branch runs `Type.classify` (via `Obj.magic` + `Null.toOption`) on the option's payload, so on `master`
   the rendered DOM literally reads `private=Some(null)`. Fails on master; passes after the fix.
  - `CHANGELOG.md`: one bullet under `# master`.

  ## Validation

  - `yarn build:test` (idempotent — no extra files modified)
  - `yarn build`
  - `yarn jest __tests__/Test_nullableScalarsAfterCustomScalarArray-tests.js --runInBand`
  - `yarn test:ci` — all 40 suites / 111 tests pass

## LLM Disclaimer
I know there are many slop PRs out there. This is a real bug I've encountered and this fix seems to address it. We've been using a shim called "fixBrokenRelayNull" in our codebase when this occurs for a while (over 50 occurrences). While I have my reservations about LLM technology and its uses, this was something that would have taken me long enough to get moving on my local machine that I would probably have continued to suffer the problem (or submitted a much less helpful bug report in the discord or something).