### PR TITLE
[codex] Upgrade ReScript Relay to Relay 21 compiler

### DIFF
--- a/packages/rescript-relay/__tests__/TestRelayUserResolver.res
+++ b/packages/rescript-relay/__tests__/TestRelayUserResolver.res
@@ -1,8 +1,5 @@
 /**
- * @RelayResolver
- *
- * @onType User
- * @fieldName fullName
+ * @relayField User.fullName: String
  * @rootFragment TestRelayUserResolver
  *
  * A users full name.
@@ -19,3 +16,5 @@ module Fragment = %relay(`
 let default = Fragment.makeRelayResolver(user => {
   Some(`${user.firstName} ${user.lastName}`)
 })
+
+let fullName = default

--- a/packages/rescript-relay/__tests__/Test_connections.res
+++ b/packages/rescript-relay/__tests__/Test_connections.res
@@ -164,10 +164,10 @@ module Test = {
       <button
         onClick={_ => {
           addFriend(
-            ~variables=AddFriendMutation.makeVariables(
+            ~variables=TestConnections_AddFriendMutation_graphql.Types.makeVariables(
               ~connections={
                 open TestConnections_user_graphql
-                [user.__id->makeConnectionId(~beforeDate=makeDate(), ())]
+                [user.__id->makeConnectionId(~beforeDate=makeDate())]
               },
               ~friendId="123",
             ),

--- a/packages/rescript-relay/__tests__/Test_customScalars.res
+++ b/packages/rescript-relay/__tests__/Test_customScalars.res
@@ -21,7 +21,7 @@ module Test = {
     let query = {
       Query.use(
         ~variables={
-          beforeDate: Some(Js.Date.fromFloat(1514764800000.)),
+          beforeDate: Js.Date.fromFloat(1514764800000.),
           number: [2],
         },
         (),
@@ -37,9 +37,9 @@ module Test = {
       </div>
       <div>
         {switch query.member {
-        | Some(#User(user)) =>
+        | Some(User(user)) =>
           React.string("member createdAt: " ++ user.createdAt->Js.Date.getTime->Js.Float.toString)
-        | Some(#UnselectedUnionMember(_)) | None => React.null
+        | Some(UnselectedUnionMember(_)) | None => React.null
         }}
       </div>
     </>

--- a/packages/rescript-relay/__tests__/Test_fragment.res
+++ b/packages/rescript-relay/__tests__/Test_fragment.res
@@ -67,8 +67,8 @@ module TestPlural = {
             user.firstName ++
             (" is " ++
             switch user.onlineStatus {
-            | Some(#Online) => "online"
-            | Some(#Offline) => "offline"
+            | Some(Online) => "online"
+            | Some(Offline) => "offline"
             | _ => "-"
             }),
           )}
@@ -96,9 +96,9 @@ module Test = {
     let _justToCheckThingsWork = switch withUnsafeEnumOpt {
     | Some(data) =>
       switch data.onlineStatus {
-      | None | Some(#Online) => "Online"
-      | Some(#Offline) => "Offline"
-      | Some(#Idle) => "Idle"
+      | None | Some(Online) => "Online"
+      | Some(Offline) => "Offline"
+      | Some(Idle) => "Idle"
       }
     | None => ""
     }
@@ -119,7 +119,7 @@ module Test = {
         data.firstName ++
         (" is " ++
         switch data.onlineStatus {
-        | Some(#Online) => "online"
+        | Some(Online) => "online"
         | _ => "-"
         }),
       )}

--- a/packages/rescript-relay/__tests__/Test_fragment_required.res
+++ b/packages/rescript-relay/__tests__/Test_fragment_required.res
@@ -56,9 +56,9 @@ module Test = {
           React.string(
             "Plain fragment: " ++
             switch fragment.onlineStatus {
-            | #Online => "Online"
-            | #Idle => "Idle"
-            | #Offline => "Offline"
+            | Online => "Online"
+            | Idle => "Idle"
+            | Offline => "Offline"
             | _ => "-"
             },
           )
@@ -77,9 +77,9 @@ module Test = {
               | Some(user) =>
                 Some(
                   switch user.onlineStatus {
-                  | #Online => "Online"
-                  | #Idle => "Idle"
-                  | #Offline => "Offline"
+                  | Online => "Online"
+                  | Idle => "Idle"
+                  | Offline => "Offline"
                   | _ => "-"
                   },
                 )

--- a/packages/rescript-relay/__tests__/Test_localPayload.res
+++ b/packages/rescript-relay/__tests__/Test_localPayload.res
@@ -12,7 +12,7 @@ module ViaNodeInterface = %relay(`
     query TestLocalPayloadViaNodeInterfaceQuery($id: ID!) @raw_response_type {
       node(id: $id) {
         ... on User {
-          ...TestLocalPayload_user
+          ...TestLocalPayload_user @alias
         }
       }
     }
@@ -77,12 +77,12 @@ module Test = {
             ->Belt.Option.getWithDefault([])
             ->Belt.Array.keepMap(v => v)
             ->Belt.Array.get(0) {
-            | Some(#Group({name, topMember})) =>
+            | Some(Group({name, topMember})) =>
               `Group ${name}, top member: ${switch topMember {
-                | Some(#User({firstName})) => firstName
+                | Some(User({firstName})) => firstName
                 | _ => "-"
                 }}`
-            | Some(#User({firstName})) => `User ${firstName}`
+            | Some(User({firstName})) => `User ${firstName}`
             | _ => "-"
             }}`,
         )}
@@ -90,8 +90,8 @@ module Test = {
       <div>
         {React.string(
           `(singular) Member of: ${switch user.memberOfSingular {
-            | Some(#Group({name})) => `Group ${name}`
-            | Some(#User({firstName})) => `User ${firstName}`
+            | Some(Group({name})) => `Group ${name}`
+            | Some(User({firstName})) => `User ${firstName}`
             | _ => "-"
             }}`,
         )}
@@ -104,16 +104,15 @@ module Test = {
             ~payload={
               loggedInUser: {
                 id: data.loggedInUser.id,
-                localStatus: Some(#On),
-                onlineStatus: Some(#Online),
+                localStatus: Some(On),
+                onlineStatus: Some(Online),
                 firstName: "AnotherFirst",
                 avatarUrl: None,
                 memberOf: None,
                 memberOfSingular: Some(
-                  #Group({
+                  Group({
                     name: "Another Group",
                     id: "group-2",
-                    __typename: #Group,
                     __isNode: #Group,
                   }),
                 ),
@@ -128,33 +127,30 @@ module Test = {
             ~environment,
             ~variables={id: data.loggedInUser.id},
             ~payload={
-              node: Some({
+              node: Some(User({
                 id: data.loggedInUser.id,
-                localStatus: Some(#On),
+                localStatus: Some(On),
                 firstName: "AnotherFirst",
-                onlineStatus: Some(#Online),
+                onlineStatus: Some(Online),
                 avatarUrl: None,
-                __typename: #User,
                 memberOfSingular: None,
                 memberOf: Some([
                   Some(
-                    #Group({
+                    Group({
                       name: "Some Group",
-                      __typename: #Group,
                       __isNode: #Group,
                       id: "group-1",
                       topMember: Some(
-                        #User({
+                        User({
                           firstName: "Some User",
                           id: "user-2",
-                          __typename: #User,
                           __isNode: #User,
                         }),
                       ),
                     }),
                   ),
                 ]),
-              }),
+              })),
             },
           )}>
         {React.string("Update locally via Node interface")}

--- a/packages/rescript-relay/__tests__/Test_missingFieldHandlers.res
+++ b/packages/rescript-relay/__tests__/Test_missingFieldHandlers.res
@@ -21,10 +21,11 @@ module RenderMe = {
   let make = () => {
     let query = Query.use(~variables=(), ~fetchPolicy=StoreOnly, ())
 
-    switch query.node {
-    | Some(user) => React.string("2: " ++ user.firstName)
-    | None => React.string("-")
-    }
+switch query.node {
+| Some(User(user)) => React.string("2: " ++ user.firstName)
+| Some(UnselectedUnionMember(_)) => React.string("-")
+| None => React.string("-")
+}
   }
 }
 

--- a/packages/rescript-relay/__tests__/Test_mutation.res
+++ b/packages/rescript-relay/__tests__/Test_mutation.res
@@ -103,9 +103,9 @@ module Test = {
         data.firstName ++
         (" is " ++
         switch data.onlineStatus {
-        | Some(#Online) => "online"
-        | Some(#Idle) => "idle"
-        | Some(#Offline) => "offline"
+        | Some(Online) => "online"
+        | Some(Idle) => "idle"
+        | Some(Offline) => "offline"
         | _ => "-"
         }),
       )}
@@ -114,7 +114,7 @@ module Test = {
         onClick={_ => {
           let _ = {
             open Mutation
-            commitMutation(~environment, ~variables=makeVariables(~onlineStatus=#Idle), ())
+            commitMutation(~environment, ~variables=TestMutationSetOnlineStatusMutation_graphql.Types.makeVariables(~onlineStatus=Idle), ())
           }
         }}>
         {React.string("Change online status")}
@@ -124,30 +124,26 @@ module Test = {
           open MutationWithOnlyFragment
           commitMutation(
             ~environment,
-            ~variables=makeVariables(~onlineStatus=#Idle),
-            ~optimisticResponse=makeOptimisticResponse(
-              ~setOnlineStatus=make_rawResponse_setOnlineStatus(
-                ~user=make_rawResponse_setOnlineStatus_user(
-                  ~id=data.id,
-                  ~firstName=data.firstName,
-                  ~lastName=data.lastName,
-                  ~memberOf=[
-                    Some(
-                      #User({
-                        __typename: #User,
-                        firstName: "test",
-                        id: "123",
-                        __isNode: #User,
-                      }),
-                    ),
-                  ],
-                  ~onlineStatus=#Idle,
-                  (),
-                ),
-                (),
-              ),
-              (),
+            ~variables=TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.Types.makeVariables(
+              ~onlineStatus=Idle,
             ),
+            ~optimisticResponse={
+              setOnlineStatus: Some({
+                user: Some({
+                  id: data.id,
+                  firstName: data.firstName,
+                  lastName: data.lastName,
+                  memberOf: Some([
+                    Some(User({
+                      firstName: "test",
+                      id: "123",
+                      __isNode: #User,
+                    })),
+                  ]),
+                  onlineStatus: Some(Idle),
+                }),
+              }),
+            },
             (),
           )->RescriptRelay.Disposable.ignore
         }}>
@@ -158,7 +154,9 @@ module Test = {
           open MutationWithInlineFragment
           commitMutation(
             ~environment,
-            ~variables=makeVariables(~onlineStatus=#Idle),
+            ~variables=TestMutationWithInlineFragmentSetOnlineStatusMutation_graphql.Types.makeVariables(
+              ~onlineStatus=Idle,
+            ),
             ~onCompleted=(response, _) => {
               setInlineStatus(_ => "completed")
               switch response {
@@ -166,9 +164,9 @@ module Test = {
                 let inlineData = InlineFragment.readInline(user.fragmentRefs)
                 setInlineStatus(_ =>
                   switch inlineData.onlineStatus {
-                  | Some(#Online) => "online"
-                  | Some(#Idle) => "idle"
-                  | Some(#Offline) => "offline"
+                  | Some(Online) => "online"
+                  | Some(Idle) => "idle"
+                  | Some(Offline) => "offline"
                   | _ => "unknown"
                   }
                 )
@@ -182,10 +180,12 @@ module Test = {
       </button>
       <button
         onClick={_ => {
-          let _ = {
-            open Mutation
-            mutate(~variables=makeVariables(~onlineStatus=#Idle), ())
-          }
+          let _ = mutate(
+            ~variables=TestMutationSetOnlineStatusMutation_graphql.Types.makeVariables(
+              ~onlineStatus=Idle,
+            ),
+            (),
+          )
         }}>
         {React.string(isMutating ? "Mutating..." : "Change online status via useMutation hook")}
       </button>
@@ -195,18 +195,21 @@ module Test = {
             open ComplexMutation
             commitMutation(
               ~environment,
-              ~variables=makeVariables(
+              ~variables=TestMutationSetOnlineStatusComplexMutation_graphql.Types.makeVariables(
                 // The "mess" below is to try and provoke a test failure if
                 // recursive conversion would be broken.
-                ~input=make_setOnlineStatusInput(
-                  ~onlineStatus=#Idle,
+                ~input=RelaySchemaAssets_graphql.make_SetOnlineStatusInput(
+                  ~onlineStatus=Idle,
                   ~someJsonValue,
-                  ~recursed=make_recursiveSetOnlineStatusInput(
+                  ~recursed=RelaySchemaAssets_graphql.make_RecursiveSetOnlineStatusInput(
                     ~someValue=100,
-                    ~setOnlineStatus=make_setOnlineStatusInput(
-                      ~onlineStatus=#Online,
+                    ~setOnlineStatus=RelaySchemaAssets_graphql.make_SetOnlineStatusInput(
+                      ~onlineStatus=Online,
                       ~someJsonValue,
-                      ~recursed=make_recursiveSetOnlineStatusInput(~someValue=100, ()),
+                      ~recursed=RelaySchemaAssets_graphql.make_RecursiveSetOnlineStatusInput(
+                        ~someValue=100,
+                        (),
+                      ),
                       (),
                     ),
                     (),
@@ -226,21 +229,18 @@ module Test = {
             open Mutation
             commitMutation(
               ~environment,
-              ~variables=makeVariables(~onlineStatus=#Idle),
-              ~optimisticResponse=makeOptimisticResponse(
-                ~setOnlineStatus=make_rawResponse_setOnlineStatus(
-                  ~user=make_rawResponse_setOnlineStatus_user(
-                    ~id=data.id,
-                    ~__id=data.id->RescriptRelay.makeDataId,
-                    ~onlineStatus=#Idle,
-                    ~firstName=data.firstName,
-                    ~lastName=data.lastName,
-                    (),
-                  ),
-                  (),
-                ),
-                (),
-              ),
+              ~variables=TestMutationSetOnlineStatusMutation_graphql.Types.makeVariables(~onlineStatus=Idle),
+              ~optimisticResponse={
+                setOnlineStatus: Some({
+                  user: Some({
+                    id: data.id,
+                    __id: Some(data.id->RescriptRelay.makeDataId),
+                    onlineStatus: Some(Idle),
+                    firstName: data.firstName,
+                    lastName: data.lastName,
+                  }),
+                }),
+              },
               (),
             )
           }
@@ -251,7 +251,7 @@ module Test = {
         onClick={_ => {
           let _ = Mutation.commitMutation(
             ~environment,
-            ~variables={onlineStatus: #Idle},
+            ~variables={onlineStatus: Idle},
             ~updater=(store, response) =>
               switch (
                 store->RescriptRelay.RecordSourceSelectorProxy.get(
@@ -267,7 +267,7 @@ module Test = {
                 ->RescriptRelay.RecordProxy.setValueString(
                   ~name="onlineStatus",
                   ~value=switch onlineStatus {
-                  | #Idle => "Offline"
+                  | Idle => "Offline"
                   | _ => "Online"
                   },
                   (),

--- a/packages/rescript-relay/__tests__/Test_nodeInterface.res
+++ b/packages/rescript-relay/__tests__/Test_nodeInterface.res
@@ -9,7 +9,7 @@ module Query = %relay(`
       node(id: "123") {
         ... on User {
           firstName
-          ...TestNodeInterface_user
+          ...TestNodeInterface_user @alias
         }
       }
     }
@@ -38,7 +38,8 @@ module Test = {
     let query = Query.use(~variables=(), ())
 
     switch query.node {
-    | Some(user) => React.string(user.firstName)
+    | Some(User(user)) => React.string(user.firstName)
+    | Some(UnselectedUnionMember(_)) => React.string("-")
     | None => React.string("-")
     }
   }

--- a/packages/rescript-relay/__tests__/Test_paginationInNode.res
+++ b/packages/rescript-relay/__tests__/Test_paginationInNode.res
@@ -3,7 +3,7 @@ module Query = %relay(`
       node(id: $userId) {
         id
         ... on User {
-          ...TestPaginationInNode_query
+          ...TestPaginationInNode_query @alias
         }
       }
     }
@@ -86,7 +86,7 @@ module UserNodeDisplayer = {
         onClick={_ => {
           startTransition(() => {
             refetch(
-              ~variables=Fragment.makeRefetchVariables(~onlineStatuses=Some([#Online, #Idle]), ()),
+              ~variables=Fragment.makeRefetchVariables(~onlineStatuses=Some([Online, Idle])),
               (),
             )->RescriptRelay.Disposable.ignore
           })
@@ -103,7 +103,10 @@ module Test = {
     let userId = "123"
     let query = Query.use(~variables={userId: userId}, ())
     switch query.node {
-    | Some(node) => <UserNodeDisplayer queryRef=node.fragmentRefs />
+    | Some(User({testPaginationInNode_query: Some(fragmentRefs)})) =>
+      <UserNodeDisplayer queryRef=fragmentRefs />
+    | Some(User({testPaginationInNode_query: None}))
+    | Some(UnselectedUnionMember(_)) => React.string("-")
     | None => React.string("-")
     }
   }

--- a/packages/rescript-relay/__tests__/Test_paginationUnion-tests.js
+++ b/packages/rescript-relay/__tests__/Test_paginationUnion-tests.js
@@ -29,6 +29,12 @@ describe("Pagination", () => {
                 friendsConnection: {
                   totalCount: 2,
                 },
+                TestPaginationUnion_user: {
+                  firstName: "First",
+                  friendsConnection: {
+                    totalCount: 2,
+                  },
+                },
               },
             },
             {
@@ -83,6 +89,12 @@ describe("Pagination", () => {
                 friendsConnection: {
                   totalCount: 4,
                 },
+                TestPaginationUnion_user: {
+                  firstName: "Second",
+                  friendsConnection: {
+                    totalCount: 4,
+                  },
+                },
               },
             },
           ],
@@ -119,6 +131,12 @@ describe("Pagination", () => {
                 friendsConnection: {
                   totalCount: 2,
                 },
+                TestPaginationUnion_user: {
+                  firstName: "First",
+                  friendsConnection: {
+                    totalCount: 2,
+                  },
+                },
               },
             },
           ],
@@ -153,6 +171,12 @@ describe("Pagination", () => {
                 firstName: "Second",
                 friendsConnection: {
                   totalCount: 4,
+                },
+                TestPaginationUnion_user: {
+                  firstName: "Second",
+                  friendsConnection: {
+                    totalCount: 4,
+                  },
                 },
               },
             },

--- a/packages/rescript-relay/__tests__/Test_paginationUnion.res
+++ b/packages/rescript-relay/__tests__/Test_paginationUnion.res
@@ -33,7 +33,7 @@ module Fragment = %relay(`
           node {
             ... on User {
               id
-              ...TestPaginationUnion_user
+              ...TestPaginationUnion_user @alias
             }
 
             ... on Group {
@@ -84,8 +84,12 @@ module Test = {
       ->Fragment.getConnectionNodes
       ->Belt.Array.mapWithIndex((i, member) =>
         switch member {
-        | #User(user) => <div key=user.id> <UserDisplayer user=user.fragmentRefs /> </div>
-        | #Group(group) =>
+        | User(user) =>
+          switch user.testPaginationUnion_user {
+          | Some(fragmentRefs) => <div key=user.id> <UserDisplayer user=fragmentRefs /> </div>
+          | None => React.null
+          }
+        | Group(group) =>
           <div key=group.id>
             {React.string(
               "Group " ++
@@ -98,7 +102,7 @@ module Test = {
               " admins"))),
             )}
           </div>
-        | #UnselectedUnionMember(_) =>
+        | UnselectedUnionMember(_) =>
           <div key={i->string_of_int}> {React.string("Unknown type")} </div>
         }
       )
@@ -114,8 +118,7 @@ module Test = {
             refetch(
               ~variables=Fragment.makeRefetchVariables(
                 ~groupId,
-                ~onlineStatuses=Some([#Online, #Idle]),
-                (),
+                ~onlineStatuses=Some([Online, Idle]),
               ),
               (),
             )->RescriptRelay.Disposable.ignore

--- a/packages/rescript-relay/__tests__/Test_query.res
+++ b/packages/rescript-relay/__tests__/Test_query.res
@@ -36,7 +36,7 @@ module TestPreloaded = {
             (user.firstName ++
             (" is " ++
             switch user.onlineStatus {
-            | Some(#Idle) => "idle"
+            | Some(Idle) => "idle"
             | _ => "-"
             })),
           )}
@@ -52,7 +52,9 @@ module Test = {
   let make = () => {
     let environment = RescriptRelay.useEnvironmentFromContext()
 
-    let (status, setStatus) = React.useState(() => Some(#Online))
+    let (status, setStatus) = React.useState(
+      (): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => Some(Online),
+    )
     let (queryRefFromModule, setQueryRefFromModule) = React.useState(() => None)
     let (hasWaitedForPreload, setHasWaitedForPreload) = React.useState(() => false)
     let (fetchedResult, setFetchedResult) = React.useState(() => None)
@@ -71,7 +73,13 @@ module Test = {
       | _ => []
       }
 
-    let query = Query.use(~variables={status: status}, ())
+    let query = Query.use(
+      ~variables=switch status {
+      | Some(status) => TestQuery_graphql.Types.makeVariables(~status)
+      | None => TestQuery_graphql.Types.makeVariables()
+      },
+      (),
+    )
     let users = collectUsers(query)
 
     <div>
@@ -82,16 +90,16 @@ module Test = {
             user.firstName ++
             (" is " ++
             switch user.onlineStatus {
-            | Some(#Online) => "online"
-            | Some(#Offline) => "offline"
-            | Some(#Idle) => "idle"
+            | Some(Online) => "online"
+            | Some(Offline) => "offline"
+            | Some(Idle) => "idle"
             | Some(_) | None => "-"
             }),
           )}
         </div>
       )
       ->React.array}
-      <button onClick={_ => setStatus(_ => Some(#Offline))}>
+      <button onClick={_ => setStatus(_ => Some(Offline))}>
         {React.string("Switch to offline")}
       </button>
       <button onClick={_ => setStatus(_ => None)}>
@@ -100,13 +108,19 @@ module Test = {
       <button
         onClick={_ =>
           setQueryRefFromModule(_ => Some(
-            TestQuery_graphql.load(~environment, ~variables={status: Some(#Idle)}, ()),
+            TestQuery_graphql.load(
+              ~environment,
+              ~variables=TestQuery_graphql.Types.makeVariables(~status=Idle),
+            ),
           ))}>
         {React.string("Test preloaded from raw module")}
       </button>
       <button
         onClick={_ => {
-          let queryRef = TestQuery_graphql.load(~environment, ~variables={status: Some(#Idle)}, ())
+          let queryRef = TestQuery_graphql.load(
+            ~environment,
+            ~variables=TestQuery_graphql.Types.makeVariables(~status=Idle),
+          )
 
           let _ = queryRef->TestQuery_graphql.queryRefToPromise->Js.Promise.then_(res => {
               switch res {
@@ -125,7 +139,7 @@ module Test = {
         onClick={_ =>
           Query.fetch(
             ~environment,
-            ~variables={status: Some(#Online)},
+            ~variables=TestQuery_graphql.Types.makeVariables(~status=Online),
             ~onResult=x =>
               switch x {
               | Ok(res) => setFetchedResult(_ => Some(collectUsers(res)))
@@ -140,7 +154,7 @@ module Test = {
           let _ =
             Query.fetchPromised(
               ~environment,
-              ~variables={status: Some(#Online)},
+              ~variables=TestQuery_graphql.Types.makeVariables(~status=Online),
               (),
             )->Js.Promise.then_(res => {
               setFetchedResult(_ => Some(collectUsers(res)))
@@ -149,7 +163,11 @@ module Test = {
         }}>
         {React.string("Test fetch promised")}
       </button>
-      <button onClick={_ => loadQuery(~variables={status: Some(#Idle)}, ())}>
+      <button
+        onClick={_ => loadQuery(
+          ~variables=TestQuery_graphql.Types.makeVariables(~status=Idle),
+          (),
+        )}>
         {React.string("Test query loader")}
       </button>
       {hasWaitedForPreload ? <div> {React.string("Has waited for preload")} </div> : React.null}
@@ -158,7 +176,7 @@ module Test = {
       | _ => React.null
       }}
       {switch fetchedResult {
-      | Some([{firstName: "First", onlineStatus: Some(#Online)}]) => React.string("Fetched!")
+      | Some([{firstName: "First", onlineStatus: Some(Online)}]) => React.string("Fetched!")
       | _ => React.null
       }}
     </div>

--- a/packages/rescript-relay/__tests__/Test_queryInputObjects.res
+++ b/packages/rescript-relay/__tests__/Test_queryInputObjects.res
@@ -8,7 +8,9 @@ module Test = {
   @react.component
   let make = () => {
     let data = Query.use(
-      ~variables=Query.makeVariables(~input=Query.make_searchInput(~id=123, ~someOtherId=1.5, ())),
+    ~variables=TestQueryInputObjectsQuery_graphql.Types.makeVariables(
+        ~input=RelaySchemaAssets_graphql.make_SearchInput(~id=123, ~someOtherId=1.5, ()),
+      ),
       (),
     )
 

--- a/packages/rescript-relay/__tests__/Test_refetching.res
+++ b/packages/rescript-relay/__tests__/Test_refetching.res
@@ -45,7 +45,7 @@ module Test = {
         data.firstName ++
         (" is " ++
         switch data.onlineStatus {
-        | Some(#Online) => "online"
+        | Some(Online) => "online"
         | _ => "-"
         }),
       )}
@@ -56,8 +56,7 @@ module Test = {
             refetch(
               ~variables=Fragment.makeRefetchVariables(
                 ~showOnlineStatus=Some(true),
-                ~friendsOnlineStatuses=Some([#Online, #Offline]),
-                (),
+                ~friendsOnlineStatuses=Some([Online, Offline]),
               ),
               (),
             )->RescriptRelay.Disposable.ignore

--- a/packages/rescript-relay/__tests__/Test_refetchingInNode-tests.js
+++ b/packages/rescript-relay/__tests__/Test_refetchingInNode-tests.js
@@ -36,7 +36,7 @@ describe("Fragment", () => {
       variables: {
         id: "user-1",
         showOnlineStatus: true,
-        friendsOnlineStatuses: null,
+        friendsOnlineStatuses: ["Online"],
       },
       data: {
         node: {

--- a/packages/rescript-relay/__tests__/Test_refetchingInNode.res
+++ b/packages/rescript-relay/__tests__/Test_refetchingInNode.res
@@ -2,7 +2,7 @@ module Query = %relay(`
     query TestRefetchingInNodeQuery($userId: ID!, $friendsOnlineStatuses: [OnlineStatus!]) {
       node(id: $userId) {
         ... on User {
-          ...TestRefetchingInNode_user @arguments(friendsOnlineStatuses: $friendsOnlineStatuses)
+          ...TestRefetchingInNode_user @arguments(friendsOnlineStatuses: $friendsOnlineStatuses) @alias
         }
       }
     }
@@ -35,7 +35,7 @@ module UserDisplayer = {
         data.firstName ++
         (" is " ++
         switch data.onlineStatus {
-        | Some(#Online) => "online"
+        | Some(Online) => "online"
         | _ => "-"
         }),
       )}
@@ -46,8 +46,6 @@ module UserDisplayer = {
             refetch(
               ~variables=Fragment.makeRefetchVariables(
                 ~showOnlineStatus=Some(true),
-                ~friendsOnlineStatuses=None,
-                (),
               ),
               (),
             )->RescriptRelay.Disposable.ignore
@@ -62,10 +60,19 @@ module UserDisplayer = {
 module Test = {
   @react.component
   let make = () => {
-    let query = Query.use(~variables={userId: "user-1", friendsOnlineStatuses: Some([#Online])}, ())
+    let query = Query.use(
+      ~variables=TestRefetchingInNodeQuery_graphql.Types.makeVariables(
+        ~userId="user-1",
+        ~friendsOnlineStatuses=[Online],
+      ),
+      (),
+    )
 
     switch query.node {
-    | Some(user) => <UserDisplayer queryRef=user.fragmentRefs />
+    | Some(User({testRefetchingInNode_user: Some(fragmentRefs)})) =>
+      <UserDisplayer queryRef=fragmentRefs />
+    | Some(User({testRefetchingInNode_user: None}))
+    | Some(UnselectedUnionMember(_)) => React.string("-")
     | None => React.string("-")
     }
   }

--- a/packages/rescript-relay/__tests__/Test_subscription.res
+++ b/packages/rescript-relay/__tests__/Test_subscription.res
@@ -54,7 +54,7 @@ module Test = {
             ->RescriptRelay.RecordProxy.setValueString(
               ~name="onlineStatus",
               ~value=switch onlineStatus {
-              | #Idle => "Offline"
+              | Idle => "Offline"
               | _ => "Online"
               },
               (),
@@ -81,8 +81,8 @@ module Test = {
           (data.firstName ++
           (" is " ++
           switch data.onlineStatus {
-          | Some(#Online) => "online"
-          | Some(#Offline) => "offline"
+          | Some(Online) => "online"
+          | Some(Offline) => "offline"
           | _ => "-"
           })),
         )}

--- a/packages/rescript-relay/__tests__/Test_unionFragment.res
+++ b/packages/rescript-relay/__tests__/Test_unionFragment.res
@@ -12,7 +12,7 @@ module Fragment = %relay(`
       ... on User {
         firstName
         onlineStatus
-        ...TestUnionFragmentUser_user
+        ...TestUnionFragmentUser_user @alias
       }
       ... on Group {
         name
@@ -32,7 +32,7 @@ module PluralFragment = %relay(`
       ... on User {
         firstName
         onlineStatus
-        ...TestUnionFragmentUser_user
+        ...TestUnionFragmentUser_user @alias
       }
       ... on Group {
         name
@@ -57,14 +57,14 @@ module FragmentRenderer = {
 
     <>
       {switch regular {
-      | #User({onlineStatus: Some(#Online), firstName, fragmentRefs}) => <>
+      | User({onlineStatus: Some(Online), firstName, testUnionFragmentUser_user: Some(fragmentRefs)}) => <>
           <div> {React.string(firstName ++ " is online")} </div>
           <UserFragmentRenderer user=fragmentRefs />
         </>
       | _ => React.null
       }}
       {switch plural {
-      | [#User({onlineStatus: Some(#Online), firstName, fragmentRefs})] => <>
+      | [User({onlineStatus: Some(Online), firstName, testUnionFragmentUser_user: Some(fragmentRefs)})] => <>
           <div> {React.string("plural: " ++ (firstName ++ " is online"))} </div>
           <UserFragmentRenderer prefix="plural: " user=fragmentRefs />
         </>

--- a/packages/rescript-relay/__tests__/Test_unions.res
+++ b/packages/rescript-relay/__tests__/Test_unions.res
@@ -34,9 +34,9 @@ module Query = %relay(`
 
 let mapOnlineStatus = (s: option<RelaySchemaAssets_graphql.enum_OnlineStatus>) =>
   switch s {
-  | Some(#Online) => "online"
-  | Some(#Offline) => "offline"
-  | Some(#Idle) => "idle"
+  | Some(Online) => "online"
+  | Some(Offline) => "offline"
+  | Some(Idle) => "idle"
   | Some(_) => "-"
   | None => "[no status]"
   }
@@ -61,11 +61,11 @@ module Test = {
       }
       ->Belt.Array.map(x =>
         switch x {
-        | #User(user) =>
+        | User(user) =>
           <div key=user.id>
             {React.string("First level: " ++ printUser(user.firstName, user.onlineStatus))}
           </div>
-        | #Group(group) =>
+        | Group(group) =>
           <div key=group.id>
             {React.string(
               "First level: " ++
@@ -76,11 +76,11 @@ module Test = {
             ->Belt.Option.getWithDefault([])
             ->Belt.Array.map(x =>
               switch x {
-              | Some(#User(user)) =>
+              | Some(User(user)) =>
                 <div key=user.id>
                   {React.string("Second level: " ++ printUser(user.firstName, user.onlineStatus))}
                 </div>
-              | Some(#Group(g)) =>
+              | Some(Group(g)) =>
                 <div key=g.id>
                   {React.string(
                     group.name ++
@@ -90,12 +90,12 @@ module Test = {
                     g.avatarUrl->Belt.Option.getWithDefault("[no avatar]")))),
                   )}
                 </div>
-              | Some(#UnselectedUnionMember(_)) | None => React.null
+              | Some(UnselectedUnionMember(_)) | None => React.null
               }
             )
             ->React.array}
           </div>
-        | #UnselectedUnionMember(_) => React.null
+        | UnselectedUnionMember(_) => React.null
         }
       )
       ->React.array}

--- a/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
@@ -1,38 +1,69 @@
 /* @generated */
-@@ocaml.warning("-30")
+@@warning("-30")
 
-@live
-type enum_OnlineStatus = private [>
-  | #Online
-  | #Idle
-  | #Offline
-]
+@live @unboxed
+type enum_OnlineStatus = 
+  | Online
+  | Idle
+  | Offline
+  | FutureAddedValue(string)
 
-@live
-type enum_OnlineStatus_input = [
-  | #Online
-  | #Idle
-  | #Offline
-]
 
-@live
-type enum_RequiredFieldAction_input = [
-  | #NONE
-  | #LOG
-  | #THROW
-]
+@live @unboxed
+type enum_OnlineStatus_input = 
+  | Online
+  | Idle
+  | Offline
 
-@live
-type enum_LocalStatus_input = [
-  | #On
-  | #Off
-]
+
+@live @unboxed
+type enum_LocalStatus = 
+  | On
+  | Off
+  | FutureAddedValue(string)
+
+
+@live @unboxed
+type enum_LocalStatus_input = 
+  | On
+  | Off
+
+
+@live @unboxed
+type enum_RequiredFieldAction = 
+  | NONE
+  | LOG
+  | THROW
+  | DANGEROUSLY_THROW_ON_SEMANTICALLY_NULLABLE_FIELD
+  | FutureAddedValue(string)
+
+
+@live @unboxed
+type enum_RequiredFieldAction_input = 
+  | NONE
+  | LOG
+  | THROW
+  | DANGEROUSLY_THROW_ON_SEMANTICALLY_NULLABLE_FIELD
+
+
+@live @unboxed
+type enum_CatchFieldTo = 
+  | NULL
+  | RESULT
+  | FutureAddedValue(string)
+
+
+@live @unboxed
+type enum_CatchFieldTo_input = 
+  | NULL
+  | RESULT
+
 
 @live
 type rec input_InputA = {
   time: TestsUtils.Datetime.t,
-  recursiveA: option<input_InputA>,
-  usingB: option<input_InputB>,
+  recursiveA?: input_InputA,
+  usingB?: input_InputB,
 }
 
 @live
@@ -44,9 +75,9 @@ and input_InputA_nullable = {
 
 @live
 and input_InputB = {
-  time: option<TestsUtils.Datetime.t>,
-  usingA: option<input_InputA>,
-  @as("constraint") constraint_: option<bool>,
+  time?: TestsUtils.Datetime.t,
+  usingA?: input_InputA,
+  @as("constraint") constraint_?: bool,
 }
 
 @live
@@ -59,7 +90,7 @@ and input_InputB_nullable = {
 @live
 and input_InputC = {
   intStr: TestsUtils.IntString.t,
-  recursiveC: option<input_InputC>,
+  recursiveC?: input_InputC,
 }
 
 @live
@@ -70,13 +101,13 @@ and input_InputC_nullable = {
 
 @live
 and input_SomeInput = {
-  str: option<string>,
-  bool: option<bool>,
-  float: option<float>,
-  int: option<int>,
-  datetime: option<TestsUtils.Datetime.t>,
-  recursive: option<input_SomeInput>,
-  @as("private") private_: option<bool>,
+  str?: string,
+  bool?: bool,
+  float?: float,
+  int?: int,
+  datetime?: TestsUtils.Datetime.t,
+  recursive?: input_SomeInput,
+  @as("private") private_?: bool,
 }
 
 @live
@@ -93,7 +124,7 @@ and input_SomeInput_nullable = {
 @live
 and input_RecursiveSetOnlineStatusInput = {
   someValue: TestsUtils.IntString.t,
-  setOnlineStatus: option<input_SetOnlineStatusInput>,
+  setOnlineStatus?: input_SetOnlineStatusInput,
 }
 
 @live
@@ -104,23 +135,23 @@ and input_RecursiveSetOnlineStatusInput_nullable = {
 
 @live
 and input_SetOnlineStatusInput = {
-  onlineStatus: [#Online | #Idle | #Offline],
+  onlineStatus: enum_OnlineStatus_input,
   someJsonValue: Js.Json.t,
-  recursed: option<input_RecursiveSetOnlineStatusInput>,
+  recursed?: input_RecursiveSetOnlineStatusInput,
 }
 
 @live
 and input_SetOnlineStatusInput_nullable = {
-  onlineStatus: [#Online | #Idle | #Offline],
+  onlineStatus: enum_OnlineStatus_input,
   someJsonValue: Js.Json.t,
   recursed?: Js.Null.t<input_RecursiveSetOnlineStatusInput_nullable>,
 }
 
 @live
 and input_SearchInput = {
-  names: option<array<option<string>>>,
+  names?: array<option<string>>,
   id: int,
-  someOtherId: option<float>,
+  someOtherId?: float,
 }
 
 @live
@@ -132,8 +163,8 @@ and input_SearchInput_nullable = {
 
 @live
 and input_PesticideListSearchInput = {
-  companyName: option<array<string>>,
-  pesticideIds: option<array<int>>,
+  companyName?: array<string>,
+  pesticideIds?: array<int>,
   skip: int,
   take: int,
 }
@@ -145,70 +176,207 @@ and input_PesticideListSearchInput_nullable = {
   skip: int,
   take: int,
 }
-@live @obj
-external make_InputA: (
+
+@live
+let make_InputA = (
   ~time: TestsUtils.Datetime.t,
-  ~recursiveA: input_InputA=?,
-  ~usingB: input_InputB=?,
-  unit,
-) => input_InputA = ""
+  ~recursiveA=?,
+  ~usingB=?,
+  (),
+): input_InputA => {
+  time,
+  recursiveA: ?recursiveA,
+  usingB: ?usingB,
+}
 
-@live @obj
-external make_InputB: (
-  ~time: TestsUtils.Datetime.t=?,
-  ~usingA: input_InputA=?,
-  @as("constraint") ~_constraint: bool=?,
-  unit,
-) => input_InputB = ""
+@live
+let make_InputA_nullable = (
+  ~time: TestsUtils.Datetime.t,
+  ~recursiveA=?,
+  ~usingB=?,
+  (),
+): input_InputA_nullable => {
+  time,
+  recursiveA: ?recursiveA,
+  usingB: ?usingB,
+}
 
-@live @obj
-external make_InputC: (
+@live
+let make_InputB = (
+  ~time=?,
+  ~usingA=?,
+  ~constraint_=?,
+  (),
+): input_InputB => {
+  time: ?time,
+  usingA: ?usingA,
+  constraint_: ?constraint_,
+}
+
+@live
+let make_InputB_nullable = (
+  ~time=?,
+  ~usingA=?,
+  ~constraint_=?,
+  (),
+): input_InputB_nullable => {
+  time: ?time,
+  usingA: ?usingA,
+  constraint_: ?constraint_,
+}
+
+@live
+let make_InputC = (
   ~intStr: TestsUtils.IntString.t,
-  ~recursiveC: input_InputC=?,
-  unit,
-) => input_InputC = ""
+  ~recursiveC=?,
+  (),
+): input_InputC => {
+  intStr,
+  recursiveC: ?recursiveC,
+}
 
-@live @obj
-external make_SomeInput: (
-  ~str: string=?,
-  ~bool: bool=?,
-  ~float: float=?,
-  ~int: int=?,
-  ~datetime: TestsUtils.Datetime.t=?,
-  ~recursive: input_SomeInput=?,
-  @as("private") ~_private: bool=?,
-  unit,
-) => input_SomeInput = ""
+@live
+let make_InputC_nullable = (
+  ~intStr: TestsUtils.IntString.t,
+  ~recursiveC=?,
+  (),
+): input_InputC_nullable => {
+  intStr,
+  recursiveC: ?recursiveC,
+}
 
-@live @obj
-external make_RecursiveSetOnlineStatusInput: (
+@live
+let make_SomeInput = (
+  ~str=?,
+  ~bool=?,
+  ~float=?,
+  ~int=?,
+  ~datetime=?,
+  ~recursive=?,
+  ~private_=?,
+  (),
+): input_SomeInput => {
+  str: ?str,
+  bool: ?bool,
+  float: ?float,
+  int: ?int,
+  datetime: ?datetime,
+  recursive: ?recursive,
+  private_: ?private_,
+}
+
+@live
+let make_SomeInput_nullable = (
+  ~str=?,
+  ~bool=?,
+  ~float=?,
+  ~int=?,
+  ~datetime=?,
+  ~recursive=?,
+  ~private_=?,
+  (),
+): input_SomeInput_nullable => {
+  str: ?str,
+  bool: ?bool,
+  float: ?float,
+  int: ?int,
+  datetime: ?datetime,
+  recursive: ?recursive,
+  private_: ?private_,
+}
+
+@live
+let make_RecursiveSetOnlineStatusInput = (
   ~someValue: TestsUtils.IntString.t,
-  ~setOnlineStatus: input_SetOnlineStatusInput=?,
-  unit,
-) => input_RecursiveSetOnlineStatusInput = ""
+  ~setOnlineStatus=?,
+  (),
+): input_RecursiveSetOnlineStatusInput => {
+  someValue,
+  setOnlineStatus: ?setOnlineStatus,
+}
 
-@live @obj
-external make_SetOnlineStatusInput: (
-  ~onlineStatus: [#Online | #Idle | #Offline],
+@live
+let make_RecursiveSetOnlineStatusInput_nullable = (
+  ~someValue: TestsUtils.IntString.t,
+  ~setOnlineStatus=?,
+  (),
+): input_RecursiveSetOnlineStatusInput_nullable => {
+  someValue,
+  setOnlineStatus: ?setOnlineStatus,
+}
+
+@live
+let make_SetOnlineStatusInput = (
+  ~onlineStatus: enum_OnlineStatus_input,
   ~someJsonValue: Js.Json.t,
-  ~recursed: input_RecursiveSetOnlineStatusInput=?,
-  unit,
-) => input_SetOnlineStatusInput = ""
+  ~recursed=?,
+  (),
+): input_SetOnlineStatusInput => {
+  onlineStatus,
+  someJsonValue,
+  recursed: ?recursed,
+}
 
-@live @obj
-external make_SearchInput: (
-  ~names: array<option<string>>=?,
+@live
+let make_SetOnlineStatusInput_nullable = (
+  ~onlineStatus: enum_OnlineStatus_input,
+  ~someJsonValue: Js.Json.t,
+  ~recursed=?,
+  (),
+): input_SetOnlineStatusInput_nullable => {
+  onlineStatus,
+  someJsonValue,
+  recursed: ?recursed,
+}
+
+@live
+let make_SearchInput = (
+  ~names=?,
   ~id: int,
-  ~someOtherId: float=?,
-  unit,
-) => input_SearchInput = ""
+  ~someOtherId=?,
+  (),
+): input_SearchInput => {
+  names: ?names,
+  id,
+  someOtherId: ?someOtherId,
+}
 
-@live @obj
-external make_PesticideListSearchInput: (
-  ~companyName: array<string>=?,
-  ~pesticideIds: array<int>=?,
+@live
+let make_SearchInput_nullable = (
+  ~names=?,
+  ~id: int,
+  ~someOtherId=?,
+  (),
+): input_SearchInput_nullable => {
+  names: ?names,
+  id,
+  someOtherId: ?someOtherId,
+}
+
+@live
+let make_PesticideListSearchInput = (
+  ~companyName=?,
+  ~pesticideIds=?,
   ~skip: int,
   ~take: int,
-  unit,
-) => input_PesticideListSearchInput = ""
+  (),
+): input_PesticideListSearchInput => {
+  companyName: ?companyName,
+  pesticideIds: ?pesticideIds,
+  skip,
+  take,
+}
 
+@live
+let make_PesticideListSearchInput_nullable = (
+  ~companyName=?,
+  ~pesticideIds=?,
+  ~skip: int,
+  ~take: int,
+  (),
+): input_PesticideListSearchInput_nullable => {
+  companyName: ?companyName,
+  pesticideIds: ?pesticideIds,
+  skip,
+  take,
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections2_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections2_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_member_User_friendsConnection_edges_node = {
     @live id: string,
@@ -13,14 +13,13 @@ module Types = {
   and fragment_member_User_friendsConnection = {
     edges: option<array<option<fragment_member_User_friendsConnection_edges>>>,
   }
-  and fragment_member_User = {
-    @live __typename: [ | #User],
-    friendsConnection: fragment_member_User_friendsConnection,
-  }
-  and fragment_member = [
-    | #User(fragment_member_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") and fragment_member = 
+    | @live User(
+      {
+        friendsConnection: fragment_member_User_friendsConnection,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type fragment = {
     member: option<fragment_member>,
@@ -28,22 +27,9 @@ module Types = {
 }
 
 @live
-let unwrap_fragment_member: {. "__typename": string } => [
-  | #User(Types.fragment_member_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment_member: Types.fragment_member => Types.fragment_member = RescriptRelay_Internal.unwrapUnion(_, ["User"])
 @live
-let wrap_fragment_member: [
-  | #User(Types.fragment_member_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment_member: Types.fragment_member => Types.fragment_member = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   type fragmentRaw
@@ -59,7 +45,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -78,17 +64,17 @@ let connectionKey = "TestConnections2_user_member_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~someInput: option<RelaySchemaAssets_graphql.input_SomeInput>=?, ~datetime: Js.null<TestsUtils.Datetime.t>=Js.null, ~flt: Js.null<float>=Js.null, ~datetime2: option<TestsUtils.Datetime.t>=?, ~datetime3: TestsUtils.Datetime.t, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~someInput: option<RelaySchemaAssets_graphql.input_SomeInput>=?, ~datetime: Js.Null.t<TestsUtils.Datetime.t>=Js.Null.empty, ~flt: Js.Null.t<float>=Js.Null.empty, ~datetime2: option<TestsUtils.Datetime.t>=?, ~datetime3: TestsUtils.Datetime.t) => {
   let datetime = datetime->Js.Null.toOption
   let datetime = switch datetime { | None => None | Some(v) => Some(TestsUtils.Datetime.serialize(v)) }
   let flt = flt->Js.Null.toOption
   let datetime2 = switch datetime2 { | None => None | Some(v) => Some(TestsUtils.Datetime.serialize(v)) }
   let datetime3 = Some(TestsUtils.Datetime.serialize(datetime3))
-  let args = {"statuses": Some(Js.null), "objTests": [RescriptRelay_Internal.Arg(Some({"str": Some("123")})), RescriptRelay_Internal.Arg(Some({"bool": Some(true)})), RescriptRelay_Internal.Arg(someInput), RescriptRelay_Internal.Arg(someInput)], "objTest": {"datetime": datetime, "recursive": {"float": flt, "datetime": datetime2, "recursive": {"datetime": datetime3}}}}
+  let args = {"statuses": Some(Js.Nullable.null), "objTests": [RescriptRelay_Internal.Arg(Some({"str": Some("123")})), RescriptRelay_Internal.Arg(Some({"bool": Some(true)})), RescriptRelay_Internal.Arg(someInput), RescriptRelay_Internal.Arg(someInput)], "objTest": {"datetime": datetime, "recursive": {"float": flt, "datetime": datetime2, "recursive": {"datetime": datetime3}}}}
   internal_makeConnectionId(connectionParentDataId, args)
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 
   @live
@@ -185,7 +171,7 @@ return {
       "name": "member",
       "plural": false,
       "selections": [
-        (v0/*: any*/),
+        (v0),
         {
           "kind": "InlineFragment",
           "selections": [
@@ -289,7 +275,7 @@ return {
                           "name": "id",
                           "storageKey": null
                         },
-                        (v0/*: any*/)
+                        (v0)
                       ],
                       "storageKey": null
                     },

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections3_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections3_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_loggedInUser_friendsConnection_edges_node = {
     @live id: string,
@@ -34,7 +34,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -58,7 +58,7 @@ let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ) => {
   internal_makeConnectionId(connectionParentDataId, args)
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections4_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections4_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_loggedInUser_friendsConnection_edges_node = {
     @live id: string,
@@ -35,7 +35,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -59,7 +59,7 @@ let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ) => {
   internal_makeConnectionId(connectionParentDataId, args)
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestConnectionsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnectionsQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestConnections_user]>,
@@ -16,18 +16,26 @@ module Types = {
   type variables = {
     beforeDate: TestsUtils.Datetime.t,
   }
-  @live
-  type refetchVariables = {
-    beforeDate: option<TestsUtils.Datetime.t>,
-  }
-  @live let makeRefetchVariables = (
-    ~beforeDate=?,
-    ()
-  ): refetchVariables => {
+  @live let makeVariables = (
+    ~beforeDate: TestsUtils.Datetime.t,
+  ): variables => {
     beforeDate: beforeDate
   }
 
+  @live
+  type refetchVariables = {
+    beforeDate?: TestsUtils.Datetime.t,
+  }
+  @live let makeRefetchVariables = (
+    ~beforeDate=?,
+  ): refetchVariables => {
+    beforeDate: ?beforeDate
+  }
+
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -42,7 +50,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -56,7 +64,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -70,7 +78,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -78,18 +86,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: (
-    ~beforeDate: TestsUtils.Datetime.t,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -115,7 +117,7 @@ v2 = [
     "name": "after",
     "value": ""
   },
-  (v1/*: any*/),
+  (v1),
   {
     "kind": "Literal",
     "name": "first",
@@ -138,7 +140,7 @@ v3 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestConnectionsQuery",
@@ -153,7 +155,7 @@ return {
         "selections": [
           {
             "args": [
-              (v1/*: any*/)
+              (v1)
             ],
             "kind": "FragmentSpread",
             "name": "TestConnections_user"
@@ -167,7 +169,7 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestConnectionsQuery",
     "selections": [
@@ -181,7 +183,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v2/*: any*/),
+            "args": (v2),
             "concreteType": "UserConnection",
             "kind": "LinkedField",
             "name": "friendsConnection",
@@ -203,7 +205,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v3),
                       {
                         "alias": null,
                         "args": null,
@@ -254,7 +256,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v2/*: any*/),
+            "args": (v2),
             "filters": [
               "statuses",
               "beforeDate"
@@ -276,7 +278,7 @@ return {
               }
             ]
           },
-          (v3/*: any*/)
+          (v3)
         ],
         "storageKey": null
       }
@@ -293,11 +295,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections_AddFriendMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections_AddFriendMutation_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_addFriend_addedFriend = {
@@ -23,6 +23,14 @@ module Types = {
     connections: array<RescriptRelay.dataId>,
     friendId: string,
   }
+  @live let makeVariables = (
+    ~connections: array<RescriptRelay.dataId>,
+    ~friendId: string,
+  ): variables => {
+    connections: connections,
+    friendId: friendId
+  }
+
 }
 
 module Internal = {
@@ -36,7 +44,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -50,7 +58,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -64,7 +72,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -74,14 +82,8 @@ module Internal = {
   let convertRawResponse = convertResponse
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: (
-    ~connections: array<RescriptRelay.dataId>,
-    ~friendId: string,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -127,8 +129,8 @@ v3 = {
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
+      (v0),
+      (v1)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -136,13 +138,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2),
         "concreteType": "AddFriendPayload",
         "kind": "LinkedField",
         "name": "addFriend",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          (v3)
         ],
         "storageKey": null
       }
@@ -153,21 +155,21 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
+      (v1),
+      (v0)
     ],
     "kind": "Operation",
     "name": "TestConnections_AddFriendMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2),
         "concreteType": "AddFriendPayload",
         "kind": "LinkedField",
         "name": "addFriend",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v3),
           {
             "alias": null,
             "args": null,

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_friendsConnection_edges_node = {
     @live id: string,
@@ -32,7 +32,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -51,14 +51,14 @@ let connectionKey = "TestConnections_user_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: array<[#Online | #Idle | #Offline]>=[#Idle], ~beforeDate: TestsUtils.Datetime.t, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: array<RelaySchemaAssets_graphql.enum_OnlineStatus>=[Idle], ~beforeDate: TestsUtils.Datetime.t) => {
   let onlineStatuses = Some(onlineStatuses)
   let beforeDate = Some(TestsUtils.Datetime.serialize(beforeDate))
   let args = {"statuses": onlineStatuses, "beforeDate": beforeDate}
   internal_makeConnectionId(connectionParentDataId, args)
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.res
@@ -2,16 +2,15 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_member_User = {
-    @live __typename: [ | #User],
-    createdAt: TestsUtils.Datetime.t,
-  }
-  and response_member = [
-    | #User(response_member_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type response_member = 
+    | @live User(
+      {
+        createdAt: TestsUtils.Datetime.t,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type rec response_loggedInUser_friends = {
     createdAt: TestsUtils.Datetime.t,
@@ -28,42 +27,39 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    beforeDate: option<TestsUtils.Datetime.t>,
+    beforeDate?: TestsUtils.Datetime.t,
     number: TestsUtils.Number.t,
   }
+  @live let makeVariables = (
+    ~beforeDate=?,
+    ~number: TestsUtils.Number.t,
+  ): variables => {
+    beforeDate: ?beforeDate,
+    number: number
+  }
+
   @live
   type refetchVariables = {
-    beforeDate: option<option<TestsUtils.Datetime.t>>,
-    number: option<TestsUtils.Number.t>,
+    beforeDate?: option<TestsUtils.Datetime.t>,
+    number?: TestsUtils.Number.t,
   }
   @live let makeRefetchVariables = (
     ~beforeDate=?,
     ~number=?,
-    ()
   ): refetchVariables => {
-    beforeDate: beforeDate,
-    number: number
+    beforeDate: ?beforeDate,
+    number: ?number
   }
 
 }
 
 @live
-let unwrap_response_member: {. "__typename": string } => [
-  | #User(Types.response_member_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_response_member: Types.response_member => Types.response_member = RescriptRelay_Internal.unwrapUnion(_, ["User"])
 @live
-let wrap_response_member: [
-  | #User(Types.response_member_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_response_member: Types.response_member => Types.response_member = RescriptRelay_Internal.wrapUnion
+
+type queryRef
+
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
@@ -78,7 +74,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -95,7 +91,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -112,7 +108,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -120,20 +116,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: (
-    ~beforeDate: TestsUtils.Datetime.t=?,
-    ~number: TestsUtils.Number.t,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -173,7 +161,7 @@ v2 = [
   }
 ],
 v3 = [
-  (v1/*: any*/)
+  (v1)
 ],
 v4 = [
   {
@@ -191,7 +179,7 @@ v5 = {
 },
 v6 = {
   "kind": "InlineFragment",
-  "selections": (v3/*: any*/),
+  "selections": (v3),
   "type": "User",
   "abstractKey": null
 },
@@ -204,7 +192,7 @@ v7 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestCustomScalarsQuery",
@@ -217,15 +205,15 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "alias": null,
-            "args": (v2/*: any*/),
+            "args": (v2),
             "concreteType": "User",
             "kind": "LinkedField",
             "name": "friends",
             "plural": true,
-            "selections": (v3/*: any*/),
+            "selections": (v3),
             "storageKey": null
           }
         ],
@@ -233,14 +221,14 @@ return {
       },
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v4),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "member",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v6/*: any*/)
+          (v5),
+          (v6)
         ],
         "storageKey": "member(id:\"user-1\")"
       }
@@ -250,7 +238,7 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestCustomScalarsQuery",
     "selections": [
@@ -262,38 +250,38 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "alias": null,
-            "args": (v2/*: any*/),
+            "args": (v2),
             "concreteType": "User",
             "kind": "LinkedField",
             "name": "friends",
             "plural": true,
             "selections": [
-              (v1/*: any*/),
-              (v7/*: any*/)
+              (v1),
+              (v7)
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v7)
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v4),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "member",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v6/*: any*/),
+          (v5),
+          (v6),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v7/*: any*/)
+              (v7)
             ],
             "type": "Node",
             "abstractKey": "__isNode"
@@ -304,21 +292,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "eb6fcc1cdc3534d168fa96d31831a59d",
+    "cacheID": "8f4f272becdd5571f35c995629b948df",
     "id": null,
     "metadata": {},
     "name": "TestCustomScalarsQuery",
     "operationKind": "query",
-    "text": "query TestCustomScalarsQuery(\n  $beforeDate: Datetime\n  $number: Number!\n) {\n  loggedInUser {\n    createdAt\n    friends(beforeDate: $beforeDate, number: $number) {\n      createdAt\n      id\n    }\n    id\n  }\n  member(id: \"user-1\") {\n    __typename\n    ... on User {\n      createdAt\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n}\n"
+    "text": "query TestCustomScalarsQuery(\n  $beforeDate: Datetime\n  $number: Number!\n) {\n  loggedInUser {\n    createdAt\n    friends(beforeDate: $beforeDate, number: $number) {\n      createdAt\n      id\n    }\n    id\n  }\n  member(id: \"user-1\") {\n    __typename\n    ... on User {\n      createdAt\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestFragment_allowUnsafeEnum | #TestFragment_inline | #TestFragment_user]>,
@@ -26,10 +26,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -42,7 +46,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -56,7 +60,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -70,7 +74,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -78,12 +82,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -92,15 +95,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -153,8 +155,8 @@ return {
             "kind": "InlineDataFragmentSpread",
             "name": "TestFragment_inline",
             "selections": [
-              (v0/*: any*/),
-              (v1/*: any*/)
+              (v0),
+              (v1)
             ],
             "args": null,
             "argumentDefinitions": []
@@ -191,8 +193,8 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
-                  (v1/*: any*/),
+                  (v2),
+                  (v1),
                   {
                     "args": null,
                     "kind": "FragmentSpread",
@@ -225,8 +227,8 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
-          (v1/*: any*/),
+          (v0),
+          (v1),
           {
             "alias": null,
             "args": null,
@@ -246,8 +248,8 @@ return {
               }
             ]
           },
-          (v1/*: any*/),
-          (v2/*: any*/)
+          (v1),
+          (v2)
         ],
         "storageKey": null
       },
@@ -275,9 +277,9 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
-                  (v1/*: any*/),
-                  (v0/*: any*/)
+                  (v2),
+                  (v1),
+                  (v0)
                 ],
                 "storageKey": null
               }
@@ -300,11 +302,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredPlural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredPlural_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment_t = {
     onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus,
@@ -23,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -33,7 +33,7 @@ external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragmentRequiredPlural_user]>> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -42,8 +42,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
@@ -73,8 +73,7 @@ let node: operationType = %raw(json` {
         "name": "onlineStatus",
         "storageKey": null
       },
-      "action": "NONE",
-      "path": "onlineStatus"
+      "action": "NONE"
     }
   ],
   "type": "User",

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestFragmentRequired_user]>,
@@ -25,10 +25,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -41,7 +45,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -55,7 +59,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -69,7 +73,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -77,14 +81,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -153,7 +155,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v0/*: any*/),
+                  (v0),
                   {
                     "args": null,
                     "kind": "FragmentSpread",
@@ -186,8 +188,8 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          (v0/*: any*/)
+          (v1),
+          (v0)
         ],
         "storageKey": null
       },
@@ -215,8 +217,8 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v0/*: any*/),
-                  (v1/*: any*/)
+                  (v0),
+                  (v1)
                 ],
                 "storageKey": null
               }
@@ -239,11 +241,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequired_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequired_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment_t = {
     onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus,
@@ -23,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -33,7 +33,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragmentRequired_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -42,8 +42,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
@@ -71,8 +71,7 @@ let node: operationType = %raw(json` {
         "name": "onlineStatus",
         "storageKey": null
       },
-      "action": "NONE",
-      "path": "onlineStatus"
+      "action": "NONE"
     }
   ],
   "type": "User",

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_allowUnsafeEnum_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_allowUnsafeEnum_graphql.res
@@ -2,15 +2,11 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     firstName: string,
-    onlineStatus: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
 }
 
@@ -27,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -37,7 +33,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_allowUnsafeEnum]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -46,8 +42,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_inline_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_inline_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     firstName: string,
@@ -23,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -33,7 +33,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_inline]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -42,8 +42,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_plural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_plural_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment_t = {
     firstName: string,
@@ -25,7 +25,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -35,7 +35,7 @@ external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragment_plural_user]>> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -44,8 +44,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_sub_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_sub_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     @live lastName: string,
@@ -22,7 +22,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -32,7 +32,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_sub_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     @live __id: RescriptRelay.dataId,
@@ -25,7 +25,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -35,7 +35,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -44,8 +44,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadQuery_graphql.res
@@ -2,67 +2,56 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  @live
-  type rec rawResponse_loggedInUser_memberOf_Group_topMember_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  @live
-  and rawResponse_loggedInUser_memberOf_Group = {
-    @live __typename: [ | #Group],
-    __isNode: [ | #Group],
-    @live id: string,
-    name: string,
-    topMember: option<rawResponse_loggedInUser_memberOf_Group_topMember>,
-  }
-  @live
-  and rawResponse_loggedInUser_memberOf_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  @live
-  and rawResponse_loggedInUser_memberOfSingular_Group = {
-    @live __typename: [ | #Group],
-    __isNode: [ | #Group],
-    @live id: string,
-    name: string,
-  }
-  @live
-  and rawResponse_loggedInUser_memberOfSingular_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  and rawResponse_loggedInUser_memberOf_Group_topMember = [
-    | #User(rawResponse_loggedInUser_memberOf_Group_topMember_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type rawResponse_loggedInUser_memberOf_Group_topMember = 
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and rawResponse_loggedInUser_memberOf = [
-    | #Group(rawResponse_loggedInUser_memberOf_Group)
-    | #User(rawResponse_loggedInUser_memberOf_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type rawResponse_loggedInUser_memberOf = 
+    | @live Group(
+      {
+        __isNode: [ | #Group],
+        @live id: string,
+        name: string,
+        topMember: option<rawResponse_loggedInUser_memberOf_Group_topMember>,
+      }
+    )
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and rawResponse_loggedInUser_memberOfSingular = [
-    | #Group(rawResponse_loggedInUser_memberOfSingular_Group)
-    | #User(rawResponse_loggedInUser_memberOfSingular_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type rawResponse_loggedInUser_memberOfSingular = 
+    | @live Group(
+      {
+        __isNode: [ | #Group],
+        @live id: string,
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type rec response_loggedInUser = {
     @live id: string,
-    localStatus: option<[
-      | #Off
-      | #On
-    ]>,
+    localStatus: option<RelaySchemaAssets_graphql.enum_LocalStatus_input>,
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestLocalPayload_user]>,
   }
   @live
@@ -70,17 +59,10 @@ module Types = {
     avatarUrl: option<string>,
     firstName: string,
     @live id: string,
-    localStatus: option<[
-      | #Off
-      | #On
-    ]>,
+    localStatus: option<RelaySchemaAssets_graphql.enum_LocalStatus_input>,
     memberOf: option<array<option<rawResponse_loggedInUser_memberOf>>>,
     memberOfSingular: option<rawResponse_loggedInUser_memberOfSingular>,
-    onlineStatus: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
   type response = {
     loggedInUser: response_loggedInUser,
@@ -91,70 +73,27 @@ module Types = {
   }
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
 
 @live
-let unwrap_rawResponse_loggedInUser_memberOf_Group_topMember: {. "__typename": string } => [
-  | #User(Types.rawResponse_loggedInUser_memberOf_Group_topMember_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
+let unwrap_rawResponse_loggedInUser_memberOf_Group_topMember: Types.rawResponse_loggedInUser_memberOf_Group_topMember => Types.rawResponse_loggedInUser_memberOf_Group_topMember = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_rawResponse_loggedInUser_memberOf_Group_topMember: Types.rawResponse_loggedInUser_memberOf_Group_topMember => Types.rawResponse_loggedInUser_memberOf_Group_topMember = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_rawResponse_loggedInUser_memberOf: Types.rawResponse_loggedInUser_memberOf => Types.rawResponse_loggedInUser_memberOf = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
+@live
+let wrap_rawResponse_loggedInUser_memberOf: Types.rawResponse_loggedInUser_memberOf => Types.rawResponse_loggedInUser_memberOf = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_rawResponse_loggedInUser_memberOfSingular: Types.rawResponse_loggedInUser_memberOfSingular => Types.rawResponse_loggedInUser_memberOfSingular = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
+@live
+let wrap_rawResponse_loggedInUser_memberOfSingular: Types.rawResponse_loggedInUser_memberOfSingular => Types.rawResponse_loggedInUser_memberOfSingular = RescriptRelay_Internal.wrapUnion
 
-@live
-let wrap_rawResponse_loggedInUser_memberOf_Group_topMember: [
-  | #User(Types.rawResponse_loggedInUser_memberOf_Group_topMember_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
-@live
-let unwrap_rawResponse_loggedInUser_memberOf: {. "__typename": string } => [
-  | #Group(Types.rawResponse_loggedInUser_memberOf_Group)
-  | #User(Types.rawResponse_loggedInUser_memberOf_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
+type queryRef
 
-@live
-let wrap_rawResponse_loggedInUser_memberOf: [
-  | #Group(Types.rawResponse_loggedInUser_memberOf_Group)
-  | #User(Types.rawResponse_loggedInUser_memberOf_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
-@live
-let unwrap_rawResponse_loggedInUser_memberOfSingular: {. "__typename": string } => [
-  | #Group(Types.rawResponse_loggedInUser_memberOfSingular_Group)
-  | #User(Types.rawResponse_loggedInUser_memberOfSingular_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
-@live
-let wrap_rawResponse_loggedInUser_memberOfSingular: [
-  | #Group(Types.rawResponse_loggedInUser_memberOfSingular_Group)
-  | #User(Types.rawResponse_loggedInUser_memberOfSingular_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
@@ -166,7 +105,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -180,7 +119,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -194,7 +133,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapRawResponseRaw
@@ -212,7 +151,7 @@ module Internal = {
   let convertWrapRawResponse = v => v->RescriptRelay.convertObj(
     wrapRawResponseConverter,
     wrapRawResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type rawResponseRaw
@@ -230,17 +169,29 @@ module Internal = {
   let convertRawResponse = v => v->RescriptRelay.convertObj(
     rawResponseConverter,
     rawResponseConverterMap,
-    Js.undefined
+    None
   )
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
+  external localStatus_toString: RelaySchemaAssets_graphql.enum_LocalStatus => string = "%identity"
+  @live
   external localStatus_input_toString: RelaySchemaAssets_graphql.enum_LocalStatus_input => string = "%identity"
+  @live
+  let localStatus_decode = (enum: RelaySchemaAssets_graphql.enum_LocalStatus): option<RelaySchemaAssets_graphql.enum_LocalStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let localStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_LocalStatus_input> => {
+    localStatus_decode(Obj.magic(str))
+  }
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
@@ -248,15 +199,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -307,7 +257,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v2/*: any*/)
+    (v2)
   ],
   "type": "User",
   "abstractKey": null
@@ -315,7 +265,7 @@ v5 = {
 v6 = {
   "kind": "InlineFragment",
   "selections": [
-    (v0/*: any*/)
+    (v0)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -335,13 +285,13 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
+          (v0),
           {
             "args": null,
             "kind": "FragmentSpread",
             "name": "TestLocalPayload_user"
           },
-          (v1/*: any*/)
+          (v1)
         ],
         "storageKey": null
       }
@@ -363,8 +313,8 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
-          (v2/*: any*/),
+          (v0),
+          (v2),
           {
             "alias": null,
             "args": null,
@@ -387,11 +337,11 @@ return {
             "name": "memberOf",
             "plural": true,
             "selections": [
-              (v3/*: any*/),
+              (v3),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v4/*: any*/),
+                  (v4),
                   {
                     "alias": null,
                     "args": null,
@@ -400,9 +350,9 @@ return {
                     "name": "topMember",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v5/*: any*/),
-                      (v6/*: any*/)
+                      (v3),
+                      (v5),
+                      (v6)
                     ],
                     "storageKey": null
                   }
@@ -410,8 +360,8 @@ return {
                 "type": "Group",
                 "abstractKey": null
               },
-              (v5/*: any*/),
-              (v6/*: any*/)
+              (v5),
+              (v6)
             ],
             "storageKey": null
           },
@@ -423,42 +373,75 @@ return {
             "name": "memberOfSingular",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
+              (v3),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v4/*: any*/)
+                  (v4)
                 ],
                 "type": "Group",
                 "abstractKey": null
               },
-              (v5/*: any*/),
-              (v6/*: any*/)
+              (v5),
+              (v6)
             ],
             "storageKey": null
           },
-          (v1/*: any*/)
+          (v1)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "077471b46af8ca6532731e3e3f851365",
+    "cacheID": "3c79db7eaae7f4b1fa8455bdf7960a6f",
     "id": null,
     "metadata": {},
     "name": "TestLocalPayloadQuery",
     "operationKind": "query",
-    "text": "query TestLocalPayloadQuery {\n  loggedInUser {\n    id\n    ...TestLocalPayload_user\n  }\n}\n\nfragment TestLocalPayload_user on User {\n  firstName\n  avatarUrl\n  onlineStatus\n  memberOf {\n    __typename\n    ... on Group {\n      name\n      topMember {\n        __typename\n        ... on User {\n          firstName\n        }\n        ... on Node {\n          __isNode: __typename\n          __typename\n          id\n        }\n      }\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n  memberOfSingular {\n    __typename\n    ... on Group {\n      name\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n}\n"
+    "text": "query TestLocalPayloadQuery {\n  loggedInUser {\n    id\n    ...TestLocalPayload_user\n  }\n}\n\nfragment TestLocalPayload_user on User {\n  firstName\n  avatarUrl\n  onlineStatus\n  memberOf {\n    __typename\n    ... on Group {\n      name\n      topMember {\n        __typename\n        ... on User {\n          firstName\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  memberOfSingular {\n    __typename\n    ... on Group {\n      name\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadViaNodeInterfaceQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadViaNodeInterfaceQuery_graphql.res
@@ -2,83 +2,75 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  @live
-  type rec rawResponse_node_memberOf_Group_topMember_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  @live
-  and rawResponse_node_memberOf_Group = {
-    @live __typename: [ | #Group],
-    __isNode: [ | #Group],
-    @live id: string,
-    name: string,
-    topMember: option<rawResponse_node_memberOf_Group_topMember>,
-  }
-  @live
-  and rawResponse_node_memberOf_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  @live
-  and rawResponse_node_memberOfSingular_Group = {
-    @live __typename: [ | #Group],
-    __isNode: [ | #Group],
-    @live id: string,
-    name: string,
-  }
-  @live
-  and rawResponse_node_memberOfSingular_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  and rawResponse_node_memberOf_Group_topMember = [
-    | #User(rawResponse_node_memberOf_Group_topMember_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type response_node = 
+    | @live User(
+      {
+        @as("TestLocalPayload_user") testLocalPayload_user: option<RescriptRelay.fragmentRefs<[ | #TestLocalPayload_user]>>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and rawResponse_node_memberOf = [
-    | #Group(rawResponse_node_memberOf_Group)
-    | #User(rawResponse_node_memberOf_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type rawResponse_node_User_memberOf_Group_topMember = 
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and rawResponse_node_memberOfSingular = [
-    | #Group(rawResponse_node_memberOfSingular_Group)
-    | #User(rawResponse_node_memberOfSingular_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type rawResponse_node_User_memberOf = 
+    | @live Group(
+      {
+        __isNode: [ | #Group],
+        @live id: string,
+        name: string,
+        topMember: option<rawResponse_node_User_memberOf_Group_topMember>,
+      }
+    )
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  type rec response_node = {
-    @live __typename: [ | #User],
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestLocalPayload_user]>,
-  }
-  @live
-  and rawResponse_node = {
-    @live __typename: [ | #User],
-    avatarUrl: option<string>,
-    firstName: string,
-    @live id: string,
-    localStatus: option<[
-      | #Off
-      | #On
-    ]>,
-    memberOf: option<array<option<rawResponse_node_memberOf>>>,
-    memberOfSingular: option<rawResponse_node_memberOfSingular>,
-    onlineStatus: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
-  }
+  @tag("__typename") type rawResponse_node_User_memberOfSingular = 
+    | @live Group(
+      {
+        __isNode: [ | #Group],
+        @live id: string,
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
+
+  @tag("__typename") type rawResponse_node = 
+    | @live User(
+      {
+        avatarUrl: option<string>,
+        firstName: string,
+        @live id: string,
+        localStatus: option<RelaySchemaAssets_graphql.enum_LocalStatus_input>,
+        memberOf: option<array<option<rawResponse_node_User_memberOf>>>,
+        memberOfSingular: option<rawResponse_node_User_memberOfSingular>,
+        onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
+
   type response = {
     node: option<response_node>,
   }
@@ -90,78 +82,47 @@ module Types = {
   type variables = {
     @live id: string,
   }
-  @live
-  type refetchVariables = {
-    @live id: option<string>,
-  }
-  @live let makeRefetchVariables = (
-    ~id=?,
-    ()
-  ): refetchVariables => {
+  @live let makeVariables = (
+    ~id: string,
+  ): variables => {
     id: id
   }
 
+  @live
+  type refetchVariables = {
+    @live id?: string,
+  }
+  @live let makeRefetchVariables = (
+    ~id=?,
+  ): refetchVariables => {
+    id: ?id
+  }
+
 }
 
 @live
-let unwrap_rawResponse_node_memberOf_Group_topMember: {. "__typename": string } => [
-  | #User(Types.rawResponse_node_memberOf_Group_topMember_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
+let unwrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_rawResponse_node_User_memberOf_Group_topMember: Types.rawResponse_node_User_memberOf_Group_topMember => Types.rawResponse_node_User_memberOf_Group_topMember = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_rawResponse_node_User_memberOf_Group_topMember: Types.rawResponse_node_User_memberOf_Group_topMember => Types.rawResponse_node_User_memberOf_Group_topMember = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_rawResponse_node_User_memberOf: Types.rawResponse_node_User_memberOf => Types.rawResponse_node_User_memberOf = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
+@live
+let wrap_rawResponse_node_User_memberOf: Types.rawResponse_node_User_memberOf => Types.rawResponse_node_User_memberOf = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_rawResponse_node_User_memberOfSingular: Types.rawResponse_node_User_memberOfSingular => Types.rawResponse_node_User_memberOfSingular = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
+@live
+let wrap_rawResponse_node_User_memberOfSingular: Types.rawResponse_node_User_memberOfSingular => Types.rawResponse_node_User_memberOfSingular = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_rawResponse_node: Types.rawResponse_node => Types.rawResponse_node = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_rawResponse_node: Types.rawResponse_node => Types.rawResponse_node = RescriptRelay_Internal.wrapUnion
 
-@live
-let wrap_rawResponse_node_memberOf_Group_topMember: [
-  | #User(Types.rawResponse_node_memberOf_Group_topMember_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
-@live
-let unwrap_rawResponse_node_memberOf: {. "__typename": string } => [
-  | #Group(Types.rawResponse_node_memberOf_Group)
-  | #User(Types.rawResponse_node_memberOf_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
+type queryRef
 
-@live
-let wrap_rawResponse_node_memberOf: [
-  | #Group(Types.rawResponse_node_memberOf_Group)
-  | #User(Types.rawResponse_node_memberOf_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
-@live
-let unwrap_rawResponse_node_memberOfSingular: {. "__typename": string } => [
-  | #Group(Types.rawResponse_node_memberOfSingular_Group)
-  | #User(Types.rawResponse_node_memberOfSingular_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
-@live
-let wrap_rawResponse_node_memberOfSingular: [
-  | #Group(Types.rawResponse_node_memberOfSingular_Group)
-  | #User(Types.rawResponse_node_memberOfSingular_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
@@ -173,81 +134,99 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
   @live
   let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User","f":""}}}`
+    json`{"__root":{"node_User_testLocalPayload_user":{"k":"TestLocalPayload_user"},"node_User_TestLocalPayload_user":{"k":"testLocalPayload_user"},"node":{"u":"response_node"}}}`
   )
   @live
-  let wrapResponseConverterMap = ()
+  let wrapResponseConverterMap = {
+    "response_node": wrap_response_node,
+  }
   @live
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
   @live
   let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User","f":""}}}`
+    json`{"__root":{"node_User_testLocalPayload_user":{"k":"TestLocalPayload_user"},"node_User_TestLocalPayload_user":{"k":"testLocalPayload_user"},"node":{"u":"response_node"}}}`
   )
   @live
-  let responseConverterMap = ()
+  let responseConverterMap = {
+    "response_node": unwrap_response_node,
+  }
   @live
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapRawResponseRaw
   @live
   let wrapRawResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node_memberOf_Group_topMember":{"u":"rawResponse_node_memberOf_Group_topMember"},"node_memberOfSingular":{"u":"rawResponse_node_memberOfSingular"},"node_memberOf":{"u":"rawResponse_node_memberOf"},"node":{"tnf":"User"}}}`
+    json`{"__root":{"node_User_memberOf_Group_topMember":{"u":"rawResponse_node_User_memberOf_Group_topMember"},"node_User_memberOfSingular":{"u":"rawResponse_node_User_memberOfSingular"},"node_User_memberOf":{"u":"rawResponse_node_User_memberOf"},"node":{"u":"rawResponse_node"}}}`
   )
   @live
   let wrapRawResponseConverterMap = {
-    "rawResponse_node_memberOf_Group_topMember": wrap_rawResponse_node_memberOf_Group_topMember,
-    "rawResponse_node_memberOf": wrap_rawResponse_node_memberOf,
-    "rawResponse_node_memberOfSingular": wrap_rawResponse_node_memberOfSingular,
+    "rawResponse_node_User_memberOf_Group_topMember": wrap_rawResponse_node_User_memberOf_Group_topMember,
+    "rawResponse_node_User_memberOf": wrap_rawResponse_node_User_memberOf,
+    "rawResponse_node_User_memberOfSingular": wrap_rawResponse_node_User_memberOfSingular,
+    "rawResponse_node": wrap_rawResponse_node,
   }
   @live
   let convertWrapRawResponse = v => v->RescriptRelay.convertObj(
     wrapRawResponseConverter,
     wrapRawResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type rawResponseRaw
   @live
   let rawResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node_memberOf_Group_topMember":{"u":"rawResponse_node_memberOf_Group_topMember"},"node_memberOfSingular":{"u":"rawResponse_node_memberOfSingular"},"node_memberOf":{"u":"rawResponse_node_memberOf"},"node":{"tnf":"User"}}}`
+    json`{"__root":{"node_User_memberOf_Group_topMember":{"u":"rawResponse_node_User_memberOf_Group_topMember"},"node_User_memberOfSingular":{"u":"rawResponse_node_User_memberOfSingular"},"node_User_memberOf":{"u":"rawResponse_node_User_memberOf"},"node":{"u":"rawResponse_node"}}}`
   )
   @live
   let rawResponseConverterMap = {
-    "rawResponse_node_memberOf_Group_topMember": unwrap_rawResponse_node_memberOf_Group_topMember,
-    "rawResponse_node_memberOf": unwrap_rawResponse_node_memberOf,
-    "rawResponse_node_memberOfSingular": unwrap_rawResponse_node_memberOfSingular,
+    "rawResponse_node_User_memberOf_Group_topMember": unwrap_rawResponse_node_User_memberOf_Group_topMember,
+    "rawResponse_node_User_memberOf": unwrap_rawResponse_node_User_memberOf,
+    "rawResponse_node_User_memberOfSingular": unwrap_rawResponse_node_User_memberOfSingular,
+    "rawResponse_node": unwrap_rawResponse_node,
   }
   @live
   let convertRawResponse = v => v->RescriptRelay.convertObj(
     rawResponseConverter,
     rawResponseConverterMap,
-    Js.undefined
+    None
   )
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
+  external localStatus_toString: RelaySchemaAssets_graphql.enum_LocalStatus => string = "%identity"
+  @live
   external localStatus_input_toString: RelaySchemaAssets_graphql.enum_LocalStatus_input => string = "%identity"
+  @live
+  let localStatus_decode = (enum: RelaySchemaAssets_graphql.enum_LocalStatus): option<RelaySchemaAssets_graphql.enum_LocalStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let localStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_LocalStatus_input> => {
+    localStatus_decode(Obj.magic(str))
+  }
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
@@ -255,19 +234,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~id: string,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -320,7 +294,7 @@ v5 = {
 v6 = {
   "kind": "InlineFragment",
   "selections": [
-    (v4/*: any*/)
+    (v4)
   ],
   "type": "User",
   "abstractKey": null
@@ -328,33 +302,44 @@ v6 = {
 v7 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestLocalPayloadViaNodeInterfaceQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v2),
           {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "TestLocalPayload_user"
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "TestLocalPayload_user"
               }
             ],
@@ -370,24 +355,24 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestLocalPayloadViaNodeInterfaceQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
+          (v2),
+          (v3),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v4/*: any*/),
+              (v4),
               {
                 "alias": null,
                 "args": null,
@@ -410,11 +395,11 @@ return {
                 "name": "memberOf",
                 "plural": true,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v5/*: any*/),
+                      (v5),
                       {
                         "alias": null,
                         "args": null,
@@ -423,9 +408,9 @@ return {
                         "name": "topMember",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
-                          (v6/*: any*/),
-                          (v7/*: any*/)
+                          (v2),
+                          (v6),
+                          (v7)
                         ],
                         "storageKey": null
                       }
@@ -433,8 +418,8 @@ return {
                     "type": "Group",
                     "abstractKey": null
                   },
-                  (v6/*: any*/),
-                  (v7/*: any*/)
+                  (v6),
+                  (v7)
                 ],
                 "storageKey": null
               },
@@ -446,17 +431,17 @@ return {
                 "name": "memberOfSingular",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v5/*: any*/)
+                      (v5)
                     ],
                     "type": "Group",
                     "abstractKey": null
                   },
-                  (v6/*: any*/),
-                  (v7/*: any*/)
+                  (v6),
+                  (v7)
                 ],
                 "storageKey": null
               },
@@ -482,21 +467,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b9ac102e28a8770beecf8ef2afeb2211",
+    "cacheID": "45d6fcdec47dbace74efbb950784e9fe",
     "id": null,
     "metadata": {},
     "name": "TestLocalPayloadViaNodeInterfaceQuery",
     "operationKind": "query",
-    "text": "query TestLocalPayloadViaNodeInterfaceQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on User {\n      ...TestLocalPayload_user\n    }\n    id\n  }\n}\n\nfragment TestLocalPayload_user on User {\n  firstName\n  avatarUrl\n  onlineStatus\n  memberOf {\n    __typename\n    ... on Group {\n      name\n      topMember {\n        __typename\n        ... on User {\n          firstName\n        }\n        ... on Node {\n          __isNode: __typename\n          __typename\n          id\n        }\n      }\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n  memberOfSingular {\n    __typename\n    ... on Group {\n      name\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n}\n"
+    "text": "query TestLocalPayloadViaNodeInterfaceQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on User {\n      ...TestLocalPayload_user\n    }\n    id\n  }\n}\n\nfragment TestLocalPayload_user on User {\n  firstName\n  avatarUrl\n  onlineStatus\n  memberOf {\n    __typename\n    ... on Group {\n      name\n      topMember {\n        __typename\n        ... on User {\n          firstName\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  memberOfSingular {\n    __typename\n    ... on Group {\n      name\n    }\n    ... on User {\n      firstName\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayload_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayload_user_graphql.res
@@ -2,53 +2,47 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec fragment_memberOf_Group_topMember_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-  }
-  and fragment_memberOf_Group = {
-    @live __typename: [ | #Group],
-    name: string,
-    topMember: option<fragment_memberOf_Group_topMember>,
-  }
-  and fragment_memberOf_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-  }
-  and fragment_memberOfSingular_Group = {
-    @live __typename: [ | #Group],
-    name: string,
-  }
-  and fragment_memberOfSingular_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-  }
-  and fragment_memberOf_Group_topMember = [
-    | #User(fragment_memberOf_Group_topMember_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type fragment_memberOf_Group_topMember = 
+    | @live User(
+      {
+        firstName: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and fragment_memberOf = [
-    | #Group(fragment_memberOf_Group)
-    | #User(fragment_memberOf_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type fragment_memberOf = 
+    | @live Group(
+      {
+        name: string,
+        topMember: option<fragment_memberOf_Group_topMember>,
+      }
+    )
+    | @live User(
+      {
+        firstName: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and fragment_memberOfSingular = [
-    | #Group(fragment_memberOfSingular_Group)
-    | #User(fragment_memberOfSingular_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type fragment_memberOfSingular = 
+    | @live Group(
+      {
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        firstName: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type fragment = {
     avatarUrl: option<string>,
     firstName: string,
-    localStatus: option<[
-      | #Off
-      | #On
-    ]>,
+    localStatus: option<RelaySchemaAssets_graphql.enum_LocalStatus_input>,
     memberOf: option<array<option<fragment_memberOf>>>,
     memberOfSingular: option<fragment_memberOfSingular>,
     onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
@@ -56,64 +50,17 @@ module Types = {
 }
 
 @live
-let unwrap_fragment_memberOf_Group_topMember: {. "__typename": string } => [
-  | #User(Types.fragment_memberOf_Group_topMember_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment_memberOf_Group_topMember: Types.fragment_memberOf_Group_topMember => Types.fragment_memberOf_Group_topMember = RescriptRelay_Internal.unwrapUnion(_, ["User"])
 @live
-let wrap_fragment_memberOf_Group_topMember: [
-  | #User(Types.fragment_memberOf_Group_topMember_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment_memberOf_Group_topMember: Types.fragment_memberOf_Group_topMember => Types.fragment_memberOf_Group_topMember = RescriptRelay_Internal.wrapUnion
 @live
-let unwrap_fragment_memberOf: {. "__typename": string } => [
-  | #Group(Types.fragment_memberOf_Group)
-  | #User(Types.fragment_memberOf_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment_memberOf: Types.fragment_memberOf => Types.fragment_memberOf = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_fragment_memberOf: [
-  | #Group(Types.fragment_memberOf_Group)
-  | #User(Types.fragment_memberOf_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment_memberOf: Types.fragment_memberOf => Types.fragment_memberOf = RescriptRelay_Internal.wrapUnion
 @live
-let unwrap_fragment_memberOfSingular: {. "__typename": string } => [
-  | #Group(Types.fragment_memberOfSingular_Group)
-  | #User(Types.fragment_memberOfSingular_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment_memberOfSingular: Types.fragment_memberOfSingular => Types.fragment_memberOfSingular = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_fragment_memberOfSingular: [
-  | #Group(Types.fragment_memberOfSingular_Group)
-  | #User(Types.fragment_memberOfSingular_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment_memberOfSingular: Types.fragment_memberOfSingular => Types.fragment_memberOfSingular = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   type fragmentRaw
@@ -131,7 +78,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -141,10 +88,23 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestLocalPayload_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
+  external localStatus_toString: RelaySchemaAssets_graphql.enum_LocalStatus => string = "%identity"
+  @live
   external localStatus_input_toString: RelaySchemaAssets_graphql.enum_LocalStatus_input => string = "%identity"
+  @live
+  let localStatus_decode = (enum: RelaySchemaAssets_graphql.enum_LocalStatus): option<RelaySchemaAssets_graphql.enum_LocalStatus_input> => {
+    switch enum {
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
+    }
+  }
+  @live
+  let localStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_LocalStatus_input> => {
+    localStatus_decode(Obj.magic(str))
+  }
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
@@ -152,8 +112,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
@@ -191,7 +151,7 @@ v2 = {
 v3 = {
   "kind": "InlineFragment",
   "selections": [
-    (v0/*: any*/)
+    (v0)
   ],
   "type": "User",
   "abstractKey": null
@@ -202,7 +162,7 @@ return {
   "metadata": null,
   "name": "TestLocalPayload_user",
   "selections": [
-    (v0/*: any*/),
+    (v0),
     {
       "alias": null,
       "args": null,
@@ -225,11 +185,11 @@ return {
       "name": "memberOf",
       "plural": true,
       "selections": [
-        (v1/*: any*/),
+        (v1),
         {
           "kind": "InlineFragment",
           "selections": [
-            (v2/*: any*/),
+            (v2),
             {
               "alias": null,
               "args": null,
@@ -238,8 +198,8 @@ return {
               "name": "topMember",
               "plural": false,
               "selections": [
-                (v1/*: any*/),
-                (v3/*: any*/)
+                (v1),
+                (v3)
               ],
               "storageKey": null
             }
@@ -247,7 +207,7 @@ return {
           "type": "Group",
           "abstractKey": null
         },
-        (v3/*: any*/)
+        (v3)
       ],
       "storageKey": null
     },
@@ -259,16 +219,16 @@ return {
       "name": "memberOfSingular",
       "plural": false,
       "selections": [
-        (v1/*: any*/),
+        (v1),
         {
           "kind": "InlineFragment",
           "selections": [
-            (v2/*: any*/)
+            (v2)
           ],
           "type": "Group",
           "abstractKey": null
         },
-        (v3/*: any*/)
+        (v3)
       ],
       "storageKey": null
     },

--- a/packages/rescript-relay/__tests__/__generated__/TestMissingFieldHandlersMeQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMissingFieldHandlersMeQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     firstName: string,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -103,7 +105,7 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/)
+          (v0)
         ],
         "storageKey": null
       }
@@ -125,7 +127,7 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
+          (v0),
           {
             "alias": null,
             "args": null,
@@ -149,11 +151,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestMissingFieldHandlersQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMissingFieldHandlersQuery_graphql.res
@@ -2,12 +2,16 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_node = {
-    @live __typename: [ | #User],
-    firstName: string,
-  }
+  @tag("__typename") type response_node = 
+    | @live User(
+      {
+        firstName: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
+
   type response = {
     node: option<response_node>,
   }
@@ -15,10 +19,18 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+@live
+let unwrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.wrapUnion
+
+type queryRef
 
 module Internal = {
   @live
@@ -31,35 +43,39 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
   @live
   let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User"}}}`
+    json`{"__root":{"node":{"u":"response_node"}}}`
   )
   @live
-  let wrapResponseConverterMap = ()
+  let wrapResponseConverterMap = {
+    "response_node": wrap_response_node,
+  }
   @live
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
   @live
   let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User"}}}`
+    json`{"__root":{"node":{"u":"response_node"}}}`
   )
   @live
-  let responseConverterMap = ()
+  let responseConverterMap = {
+    "response_node": unwrap_response_node,
+  }
   @live
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -67,14 +83,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -119,14 +133,14 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          (v2/*: any*/)
+          (v1),
+          (v2)
         ],
         "storageKey": "node(id:\"123\")"
       }
@@ -142,14 +156,14 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          (v2/*: any*/),
+          (v1),
+          (v2),
           {
             "alias": null,
             "args": null,
@@ -173,11 +187,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationInline_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationInline_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     firstName: string,
@@ -25,7 +25,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -35,7 +35,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestMutationInline_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -44,8 +44,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestMutation_user]>,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -136,8 +138,8 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
-          (v1/*: any*/),
+          (v0),
+          (v1),
           {
             "alias": null,
             "args": null,
@@ -170,7 +172,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v1/*: any*/)
+                  (v1)
                 ],
                 "type": "User",
                 "abstractKey": null
@@ -192,7 +194,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v0/*: any*/)
+                  (v0)
                 ],
                 "type": "Node",
                 "abstractKey": "__isNode"
@@ -206,21 +208,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d3f38be28b6ab5f607e13d37697e05dc",
+    "cacheID": "367ab31b7c5cebe2e00b1d0315cf2da4",
     "id": null,
     "metadata": {},
     "name": "TestMutationQuery",
     "operationKind": "query",
-    "text": "query TestMutationQuery {\n  loggedInUser {\n    ...TestMutation_user\n    id\n  }\n}\n\nfragment TestMutation_user on User {\n  id\n  firstName\n  lastName\n  onlineStatus\n  memberOf {\n    __typename\n    ... on User {\n      firstName\n    }\n    ... on Group {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n}\n"
+    "text": "query TestMutationQuery {\n  loggedInUser {\n    ...TestMutation_user\n    id\n  }\n}\n\nfragment TestMutation_user on User {\n  id\n  firstName\n  lastName\n  onlineStatus\n  memberOf {\n    __typename\n    ... on User {\n      firstName\n    }\n    ... on Group {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live type setOnlineStatusInput = RelaySchemaAssets_graphql.input_SetOnlineStatusInput
   @live type recursiveSetOnlineStatusInput = RelaySchemaAssets_graphql.input_RecursiveSetOnlineStatusInput
@@ -25,6 +25,12 @@ module Types = {
   type variables = {
     input: setOnlineStatusInput,
   }
+  @live let makeVariables = (
+    ~input: setOnlineStatusInput,
+  ): variables => {
+    input: input
+  }
+
 }
 
 module Internal = {
@@ -40,7 +46,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -54,7 +60,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -68,7 +74,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -78,7 +84,7 @@ module Internal = {
   let convertRawResponse = convertResponse
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -87,38 +93,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external make_setOnlineStatusInput: (
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
-    ~recursed: recursiveSetOnlineStatusInput=?,
-    ~someJsonValue: Js.Json.t,
-    unit
-  ) => setOnlineStatusInput = ""
-
-
-  @live @obj external make_recursiveSetOnlineStatusInput: (
-    ~setOnlineStatus: setOnlineStatusInput=?,
-    ~someValue: TestsUtils.IntString.t,
-    unit
-  ) => recursiveSetOnlineStatusInput = ""
-
-
-  @live @obj external makeVariables: (
-    ~input: setOnlineStatusInput,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -179,20 +161,20 @@ v1 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestMutationSetOnlineStatusComplexMutation",
-    "selections": (v1/*: any*/),
+    "selections": (v1),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestMutationSetOnlineStatusComplexMutation",
-    "selections": (v1/*: any*/)
+    "selections": (v1)
   },
   "params": {
     "cacheID": "20484379745a128851fbf94268a240bf",

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_setOnlineStatus_user = {
@@ -20,11 +20,7 @@ module Types = {
     firstName: string,
     @live id: string,
     lastName: string,
-    onlineStatus: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
   @live
   and rawResponse_setOnlineStatus = {
@@ -40,12 +36,14 @@ module Types = {
   }
   @live
   type variables = {
-    onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
+    onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
   }
+  @live let makeVariables = (
+    ~onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
+  ): variables => {
+    onlineStatus: onlineStatus
+  }
+
 }
 
 module Internal = {
@@ -59,7 +57,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -73,7 +71,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -87,7 +85,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapRawResponseRaw
@@ -101,7 +99,7 @@ module Internal = {
   let convertWrapRawResponse = v => v->RescriptRelay.convertObj(
     wrapRawResponseConverter,
     wrapRawResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type rawResponseRaw
@@ -115,11 +113,11 @@ module Internal = {
   let convertRawResponse = v => v->RescriptRelay.convertObj(
     rawResponseConverter,
     rawResponseConverterMap,
-    Js.undefined
+    None
   )
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -128,49 +126,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
-  ) => variables = ""
-
-
-  @live @obj external makeOptimisticResponse: (
-    ~setOnlineStatus: rawResponse_setOnlineStatus=?,
-    unit
-  ) => rawResponse = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus_user: (
-    ~__id: RescriptRelay.dataId=?,
-    ~firstName: string,
-    ~id: string,
-    ~lastName: string,
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ]=?,
-    unit
-  ) => rawResponse_setOnlineStatus_user = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus: (
-    ~user: rawResponse_setOnlineStatus_user=?,
-    unit
-  ) => rawResponse_setOnlineStatus = ""
-
-
 }
 
 type relayOperationNode
@@ -208,14 +171,14 @@ v3 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestMutationSetOnlineStatusMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "SetOnlineStatusPayload",
         "kind": "LinkedField",
         "name": "setOnlineStatus",
@@ -229,8 +192,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2),
+              (v3),
               {
                 "args": null,
                 "kind": "FragmentSpread",
@@ -248,13 +211,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestMutationSetOnlineStatusMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "SetOnlineStatusPayload",
         "kind": "LinkedField",
         "name": "setOnlineStatus",
@@ -268,8 +231,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2),
+              (v3),
               {
                 "alias": null,
                 "args": null,

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationWithInlineFragmentSetOnlineStatusMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationWithInlineFragmentSetOnlineStatusMutation_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_setOnlineStatus_user = {
@@ -17,11 +17,7 @@ module Types = {
     firstName: string,
     @live id: string,
     lastName: string,
-    onlineStatus: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
   @live
   and rawResponse_setOnlineStatus = {
@@ -37,12 +33,14 @@ module Types = {
   }
   @live
   type variables = {
-    onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
+    onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
   }
+  @live let makeVariables = (
+    ~onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
+  ): variables => {
+    onlineStatus: onlineStatus
+  }
+
 }
 
 module Internal = {
@@ -56,7 +54,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -70,7 +68,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -84,7 +82,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapRawResponseRaw
@@ -98,7 +96,7 @@ module Internal = {
   let convertWrapRawResponse = v => v->RescriptRelay.convertObj(
     wrapRawResponseConverter,
     wrapRawResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type rawResponseRaw
@@ -112,11 +110,11 @@ module Internal = {
   let convertRawResponse = v => v->RescriptRelay.convertObj(
     rawResponseConverter,
     rawResponseConverterMap,
-    Js.undefined
+    None
   )
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -125,48 +123,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
-  ) => variables = ""
-
-
-  @live @obj external makeOptimisticResponse: (
-    ~setOnlineStatus: rawResponse_setOnlineStatus=?,
-    unit
-  ) => rawResponse = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus_user: (
-    ~firstName: string,
-    ~id: string,
-    ~lastName: string,
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ]=?,
-    unit
-  ) => rawResponse_setOnlineStatus_user = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus: (
-    ~user: rawResponse_setOnlineStatus_user=?,
-    unit
-  ) => rawResponse_setOnlineStatus = ""
-
-
 }
 
 type relayOperationNode
@@ -220,14 +184,14 @@ v2 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestMutationWithInlineFragmentSetOnlineStatusMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "SetOnlineStatusPayload",
         "kind": "LinkedField",
         "name": "setOnlineStatus",
@@ -244,7 +208,7 @@ return {
               {
                 "kind": "InlineDataFragmentSpread",
                 "name": "TestMutationInline_user",
-                "selections": (v2/*: any*/),
+                "selections": (v2),
                 "args": null,
                 "argumentDefinitions": []
               }
@@ -260,13 +224,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestMutationWithInlineFragmentSetOnlineStatusMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "SetOnlineStatusPayload",
         "kind": "LinkedField",
         "name": "setOnlineStatus",
@@ -279,7 +243,7 @@ return {
             "kind": "LinkedField",
             "name": "user",
             "plural": false,
-            "selections": (v2/*: any*/),
+            "selections": (v2),
             "storageKey": null
           }
         ],

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.res
@@ -2,27 +2,24 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  @live
-  type rec rawResponse_setOnlineStatus_user_memberOf_Group = {
-    @live __typename: [ | #Group],
-    __isNode: [ | #Group],
-    @live id: string,
-    name: string,
-  }
-  @live
-  and rawResponse_setOnlineStatus_user_memberOf_User = {
-    @live __typename: [ | #User],
-    __isNode: [ | #User],
-    firstName: string,
-    @live id: string,
-  }
-  and rawResponse_setOnlineStatus_user_memberOf = [
-    | #Group(rawResponse_setOnlineStatus_user_memberOf_Group)
-    | #User(rawResponse_setOnlineStatus_user_memberOf_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type rawResponse_setOnlineStatus_user_memberOf = 
+    | @live Group(
+      {
+        __isNode: [ | #Group],
+        @live id: string,
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        __isNode: [ | #User],
+        firstName: string,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   @live
   type rec response_setOnlineStatus_user = {
@@ -38,11 +35,7 @@ module Types = {
     @live id: string,
     lastName: string,
     memberOf: option<array<option<rawResponse_setOnlineStatus_user_memberOf>>>,
-    onlineStatus: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
+    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
   @live
   and rawResponse_setOnlineStatus = {
@@ -58,35 +51,20 @@ module Types = {
   }
   @live
   type variables = {
-    onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
+    onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
   }
+  @live let makeVariables = (
+    ~onlineStatus: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
+  ): variables => {
+    onlineStatus: onlineStatus
+  }
+
 }
 
 @live
-let unwrap_rawResponse_setOnlineStatus_user_memberOf: {. "__typename": string } => [
-  | #Group(Types.rawResponse_setOnlineStatus_user_memberOf_Group)
-  | #User(Types.rawResponse_setOnlineStatus_user_memberOf_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_rawResponse_setOnlineStatus_user_memberOf: Types.rawResponse_setOnlineStatus_user_memberOf => Types.rawResponse_setOnlineStatus_user_memberOf = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_rawResponse_setOnlineStatus_user_memberOf: [
-  | #Group(Types.rawResponse_setOnlineStatus_user_memberOf_Group)
-  | #User(Types.rawResponse_setOnlineStatus_user_memberOf_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_rawResponse_setOnlineStatus_user_memberOf: Types.rawResponse_setOnlineStatus_user_memberOf => Types.rawResponse_setOnlineStatus_user_memberOf = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
@@ -98,7 +76,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -112,7 +90,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -126,7 +104,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapRawResponseRaw
@@ -142,7 +120,7 @@ module Internal = {
   let convertWrapRawResponse = v => v->RescriptRelay.convertObj(
     wrapRawResponseConverter,
     wrapRawResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type rawResponseRaw
@@ -158,11 +136,11 @@ module Internal = {
   let convertRawResponse = v => v->RescriptRelay.convertObj(
     rawResponseConverter,
     rawResponseConverterMap,
-    Js.undefined
+    None
   )
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -171,65 +149,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
-  ) => variables = ""
-
-
-  @live @obj external makeOptimisticResponse: (
-    ~setOnlineStatus: rawResponse_setOnlineStatus=?,
-    unit
-  ) => rawResponse = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus_user_memberOf_Group: (
-    ~__typename: [ | #Group],
-    ~__isNode: [ | #Group],
-    ~id: string,
-    ~name: string,
-  ) => rawResponse_setOnlineStatus_user_memberOf_Group = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus_user_memberOf_User: (
-    ~__typename: [ | #User],
-    ~__isNode: [ | #User],
-    ~firstName: string,
-    ~id: string,
-  ) => rawResponse_setOnlineStatus_user_memberOf_User = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus_user: (
-    ~firstName: string,
-    ~id: string,
-    ~lastName: string,
-    ~memberOf: array<option<rawResponse_setOnlineStatus_user_memberOf>>=?,
-    ~onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ]=?,
-    unit
-  ) => rawResponse_setOnlineStatus_user = ""
-
-
-  @live @obj external make_rawResponse_setOnlineStatus: (
-    ~user: rawResponse_setOnlineStatus_user=?,
-    unit
-  ) => rawResponse_setOnlineStatus = ""
-
-
 }
 
 type relayOperationNode
@@ -267,14 +194,14 @@ v3 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestMutationWithOnlyFragmentSetOnlineStatusMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "SetOnlineStatusPayload",
         "kind": "LinkedField",
         "name": "setOnlineStatus",
@@ -305,13 +232,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestMutationWithOnlyFragmentSetOnlineStatusMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "SetOnlineStatusPayload",
         "kind": "LinkedField",
         "name": "setOnlineStatus",
@@ -325,8 +252,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2),
+              (v3),
               {
                 "alias": null,
                 "args": null,
@@ -359,7 +286,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/)
+                      (v3)
                     ],
                     "type": "User",
                     "abstractKey": null
@@ -381,7 +308,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v2/*: any*/)
+                      (v2)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -398,12 +325,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "322a5bb9a0514feff61365f595c40d31",
+    "cacheID": "e0feba611b52ad3b8ccb480d649750c3",
     "id": null,
     "metadata": {},
     "name": "TestMutationWithOnlyFragmentSetOnlineStatusMutation",
     "operationKind": "mutation",
-    "text": "mutation TestMutationWithOnlyFragmentSetOnlineStatusMutation(\n  $onlineStatus: OnlineStatus!\n) {\n  setOnlineStatus(onlineStatus: $onlineStatus) {\n    user {\n      ...TestMutation_user\n      id\n    }\n  }\n}\n\nfragment TestMutation_user on User {\n  id\n  firstName\n  lastName\n  onlineStatus\n  memberOf {\n    __typename\n    ... on User {\n      firstName\n    }\n    ... on Group {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n}\n"
+    "text": "mutation TestMutationWithOnlyFragmentSetOnlineStatusMutation(\n  $onlineStatus: OnlineStatus!\n) {\n  setOnlineStatus(onlineStatus: $onlineStatus) {\n    user {\n      ...TestMutation_user\n      id\n    }\n  }\n}\n\nfragment TestMutation_user on User {\n  id\n  firstName\n  lastName\n  onlineStatus\n  memberOf {\n    __typename\n    ... on User {\n      firstName\n    }\n    ... on Group {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })() `)

--- a/packages/rescript-relay/__tests__/__generated__/TestMutation_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutation_user_graphql.res
@@ -2,21 +2,20 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec fragment_memberOf_Group = {
-    @live __typename: [ | #Group],
-    name: string,
-  }
-  and fragment_memberOf_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-  }
-  and fragment_memberOf = [
-    | #Group(fragment_memberOf_Group)
-    | #User(fragment_memberOf_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type fragment_memberOf = 
+    | @live Group(
+      {
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        firstName: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type fragment = {
     firstName: string,
@@ -28,26 +27,9 @@ module Types = {
 }
 
 @live
-let unwrap_fragment_memberOf: {. "__typename": string } => [
-  | #Group(Types.fragment_memberOf_Group)
-  | #User(Types.fragment_memberOf_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment_memberOf: Types.fragment_memberOf => Types.fragment_memberOf = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_fragment_memberOf: [
-  | #Group(Types.fragment_memberOf_Group)
-  | #User(Types.fragment_memberOf_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment_memberOf: Types.fragment_memberOf => Types.fragment_memberOf = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   type fragmentRaw
@@ -63,7 +45,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -73,7 +55,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestMutation_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -82,8 +64,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
@@ -117,7 +99,7 @@ return {
       "name": "id",
       "storageKey": null
     },
-    (v0/*: any*/),
+    (v0),
     {
       "alias": null,
       "args": null,
@@ -150,7 +132,7 @@ return {
         {
           "kind": "InlineFragment",
           "selections": [
-            (v0/*: any*/)
+            (v0)
           ],
           "type": "User",
           "abstractKey": null

--- a/packages/rescript-relay/__tests__/__generated__/TestNodeInterfaceOnAbstractTypeQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNodeInterfaceOnAbstractTypeQuery_graphql.res
@@ -2,21 +2,20 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_node_Group = {
-    @live __typename: [ | #Group],
-    name: option<string>,
-  }
-  and response_node_User = {
-    @live __typename: [ | #User],
-    firstName: option<string>,
-  }
-  and response_node = [
-    | #Group(response_node_Group)
-    | #User(response_node_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type response_node = 
+    | @live Group(
+      {
+        name: option<string>,
+      }
+    )
+    | @live User(
+      {
+        firstName: option<string>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type response = {
     node: option<response_node>,
@@ -25,32 +24,19 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
 
 @live
-let unwrap_response_node: {. "__typename": string } => [
-  | #Group(Types.response_node_Group)
-  | #User(Types.response_node_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_response_node: [
-  | #Group(Types.response_node_Group)
-  | #User(Types.response_node_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.wrapUnion
+
+type queryRef
+
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
@@ -62,7 +48,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -78,7 +64,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -94,7 +80,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -102,14 +88,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -135,29 +119,36 @@ v2 = {
   "kind": "InlineFragment",
   "selections": [
     {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "firstName",
-      "storageKey": null
-    }
-  ],
-  "type": "User",
-  "abstractKey": null
-},
-v3 = {
-  "kind": "InlineFragment",
-  "selections": [
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "firstName",
+          "storageKey": null
+        }
+      ],
+      "type": "User",
+      "abstractKey": null
+    },
     {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "type": "Group",
+      "abstractKey": null
     }
   ],
-  "type": "Group",
-  "abstractKey": null
+  "type": "Member",
+  "abstractKey": "__isMember"
 };
 return {
   "fragment": {
@@ -168,23 +159,14 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          {
-            "kind": "InlineFragment",
-            "selections": [
-              (v1/*: any*/),
-              (v2/*: any*/),
-              (v3/*: any*/)
-            ],
-            "type": "Member",
-            "abstractKey": "__isMember"
-          }
+          (v1),
+          (v2)
         ],
         "storageKey": "node(id:\"123\")"
       }
@@ -200,13 +182,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "alias": null,
             "args": null,
@@ -214,36 +196,61 @@ return {
             "name": "id",
             "storageKey": null
           },
-          {
-            "kind": "InlineFragment",
-            "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/)
-            ],
-            "type": "Member",
-            "abstractKey": "__isMember"
-          }
+          (v2)
         ],
         "storageKey": "node(id:\"123\")"
       }
     ]
   },
   "params": {
-    "cacheID": "2b0a77873bd94a6208022409d53b9e5e",
+    "cacheID": "22e6de6866d059c4c7df3a8de871efdc",
     "id": null,
     "metadata": {},
     "name": "TestNodeInterfaceOnAbstractTypeQuery",
     "operationKind": "query",
-    "text": "query TestNodeInterfaceOnAbstractTypeQuery {\n  node(id: \"123\") {\n    __typename\n    ... on Member {\n      __isMember: __typename\n      __typename\n      ... on User {\n        firstName\n      }\n      ... on Group {\n        name\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TestNodeInterfaceOnAbstractTypeQuery {\n  node(id: \"123\") {\n    __typename\n    ... on Member {\n      __isMember: __typename\n      ... on User {\n        firstName\n      }\n      ... on Group {\n        name\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestNodeInterfaceQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNodeInterfaceQuery_graphql.res
@@ -2,13 +2,17 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_node = {
-    @live __typename: [ | #User],
-    firstName: string,
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestNodeInterface_user]>,
-  }
+  @tag("__typename") type response_node = 
+    | @live User(
+      {
+        @as("TestNodeInterface_user") testNodeInterface_user: option<RescriptRelay.fragmentRefs<[ | #TestNodeInterface_user]>>,
+        firstName: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
+
   type response = {
     node: option<response_node>,
   }
@@ -16,10 +20,18 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+@live
+let unwrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.wrapUnion
+
+type queryRef
 
 module Internal = {
   @live
@@ -32,35 +44,39 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
   @live
   let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User","f":""}}}`
+    json`{"__root":{"node_User_testNodeInterface_user":{"k":"TestNodeInterface_user"},"node_User_TestNodeInterface_user":{"k":"testNodeInterface_user"},"node":{"u":"response_node"}}}`
   )
   @live
-  let wrapResponseConverterMap = ()
+  let wrapResponseConverterMap = {
+    "response_node": wrap_response_node,
+  }
   @live
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
   @live
   let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User","f":""}}}`
+    json`{"__root":{"node_User_testNodeInterface_user":{"k":"TestNodeInterface_user"},"node_User_TestNodeInterface_user":{"k":"testNodeInterface_user"},"node":{"u":"response_node"}}}`
   )
   @live
-  let responseConverterMap = ()
+  let responseConverterMap = {
+    "response_node": unwrap_response_node,
+  }
   @live
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -68,14 +84,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -113,20 +127,31 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v2/*: any*/),
+              (v2),
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "TestNodeInterface_user"
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "TestNodeInterface_user"
               }
             ],
@@ -148,17 +173,17 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v2/*: any*/)
+              (v2)
             ],
             "type": "User",
             "abstractKey": null
@@ -186,11 +211,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestNodeInterface_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNodeInterface_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     firstName: string,
@@ -22,7 +22,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -32,7 +32,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestNodeInterface_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesMutation_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live type someInput = RelaySchemaAssets_graphql.input_SomeInput_nullable
   @live
@@ -25,12 +25,20 @@ module Types = {
     avatarUrl?: Js.Null.t<string>,
     someInput?: Js.Null.t<someInput>,
   }
+  @live let makeVariables = (
+    ~avatarUrl=?,
+    ~someInput=?,
+  ): variables => {
+    avatarUrl: ?avatarUrl,
+    someInput: ?someInput
+  }
+
 }
 
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"someInput":{"recursive":{"r":"someInput"},"datetime":{"c":"TestsUtils.Datetime"}},"__root":{"someInput":{"r":"someInput"}}}`
+    json`{"someInput":{"recursive":{"r":"someInput"},"private_":{"k":"private"},"private":{"k":"private_"},"datetime":{"c":"TestsUtils.Datetime"}},"__root":{"someInput":{"r":"someInput"}}}`
   )
   @live
   let variablesConverterMap = {
@@ -40,7 +48,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type wrapResponseRaw
@@ -54,7 +62,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -68,7 +76,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -78,27 +86,8 @@ module Internal = {
   let convertRawResponse = convertResponse
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external make_someInput: (
-    ~bool: bool=?,
-    ~datetime: TestsUtils.Datetime.t=?,
-    ~float: float=?,
-    ~int: int=?,
-    @as("private") ~_private: bool=?,
-    ~recursive: someInput=?,
-    ~str: string=?,
-    unit
-  ) => someInput = ""
-
-
-  @live @obj external makeVariables: (
-    ~avatarUrl: string=?,
-    ~someInput: someInput=?,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -147,14 +136,14 @@ v3 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestNullableVariablesMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "UpdateUserAvatarPayload",
         "kind": "LinkedField",
         "name": "updateUserAvatar",
@@ -168,8 +157,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/)
+              (v2),
+              (v3)
             ],
             "storageKey": null
           }
@@ -182,13 +171,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestNullableVariablesMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "UpdateUserAvatarPayload",
         "kind": "LinkedField",
         "name": "updateUserAvatar",
@@ -202,8 +191,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2),
+              (v3),
               {
                 "alias": null,
                 "args": null,

--- a/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     avatarUrl: option<string>,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -103,7 +105,7 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/)
+          (v0)
         ],
         "storageKey": null
       }
@@ -125,7 +127,7 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
+          (v0),
           {
             "alias": null,
             "args": null,
@@ -149,11 +151,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestObserverQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestObserverQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     @live id: string,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -107,7 +109,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "TestObserverQuery",
-    "selections": (v0/*: any*/),
+    "selections": (v0),
     "type": "Query",
     "abstractKey": null
   },
@@ -116,7 +118,7 @@ return {
     "argumentDefinitions": [],
     "kind": "Operation",
     "name": "TestObserverQuery",
-    "selections": (v0/*: any*/)
+    "selections": (v0)
   },
   "params": {
     "cacheID": "d11d006503ea82c423da752e9fc1fd46",
@@ -129,11 +131,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.res
@@ -2,13 +2,17 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_node = {
-    @live __typename: string,
-    @live id: string,
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestPaginationInNode_query]>,
-  }
+  @tag("__typename") type response_node = 
+    | @live User(
+      {
+        @as("TestPaginationInNode_query") testPaginationInNode_query: option<RescriptRelay.fragmentRefs<[ | #TestPaginationInNode_query]>>,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
+
   type response = {
     node: option<response_node>,
   }
@@ -18,18 +22,30 @@ module Types = {
   type variables = {
     userId: string,
   }
-  @live
-  type refetchVariables = {
-    userId: option<string>,
-  }
-  @live let makeRefetchVariables = (
-    ~userId=?,
-    ()
-  ): refetchVariables => {
+  @live let makeVariables = (
+    ~userId: string,
+  ): variables => {
     userId: userId
   }
 
+  @live
+  type refetchVariables = {
+    userId?: string,
+  }
+  @live let makeRefetchVariables = (
+    ~userId=?,
+  ): refetchVariables => {
+    userId: ?userId
+  }
+
 }
+
+@live
+let unwrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.wrapUnion
+
+type queryRef
 
 module Internal = {
   @live
@@ -42,35 +58,39 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
   @live
   let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"f":""}}}`
+    json`{"__root":{"node_User_testPaginationInNode_query":{"k":"TestPaginationInNode_query"},"node_User_TestPaginationInNode_query":{"k":"testPaginationInNode_query"},"node":{"u":"response_node"}}}`
   )
   @live
-  let wrapResponseConverterMap = ()
+  let wrapResponseConverterMap = {
+    "response_node": wrap_response_node,
+  }
   @live
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
   @live
   let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"f":""}}}`
+    json`{"__root":{"node_User_testPaginationInNode_query":{"k":"TestPaginationInNode_query"},"node_User_TestPaginationInNode_query":{"k":"testPaginationInNode_query"},"node":{"u":"response_node"}}}`
   )
   @live
-  let responseConverterMap = ()
+  let responseConverterMap = {
+    "response_node": unwrap_response_node,
+  }
   @live
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -78,18 +98,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: (
-    ~userId: string,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -139,27 +153,38 @@ v4 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestPaginationInNodeQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
+          (v2),
+          (v3),
           {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "TestPaginationInNode_query"
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "TestPaginationInNode_query"
               }
             ],
@@ -175,26 +200,26 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestPaginationInNodeQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
+          (v2),
+          (v3),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v4),
                 "concreteType": "UserConnection",
                 "kind": "LinkedField",
                 "name": "friendsConnection",
@@ -216,7 +241,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
+                          (v3),
                           {
                             "alias": null,
                             "args": null,
@@ -248,7 +273,7 @@ return {
                             ],
                             "storageKey": "friendsConnection(first:1)"
                           },
-                          (v2/*: any*/)
+                          (v2)
                         ],
                         "storageKey": null
                       },
@@ -292,7 +317,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v4),
                 "filters": [
                   "statuses"
                 ],
@@ -321,11 +346,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.res
@@ -2,11 +2,10 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_node = {
-    @live __typename: string,
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestPaginationInNode_query]>,
   }
   @live
@@ -17,40 +16,46 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    count: option<int>,
-    cursor: option<string>,
+    count?: int,
+    cursor?: string,
     @live id: string,
-    onlineStatuses: option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>,
+    onlineStatuses?: array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
+  @live let makeVariables = (
+    ~count=?,
+    ~cursor=?,
+    ~id: string,
+    ~onlineStatuses=?,
+  ): variables => {
+    count: ?count,
+    cursor: ?cursor,
+    id: id,
+    onlineStatuses: ?onlineStatuses
+  }
+
   @live
   type refetchVariables = {
-    count: option<option<int>>,
-    cursor: option<option<string>>,
-    @live id: option<string>,
-    onlineStatuses: option<option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>>,
+    count?: option<int>,
+    cursor?: option<string>,
+    @live id?: string,
+    onlineStatuses?: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>>,
   }
   @live let makeRefetchVariables = (
     ~count=?,
     ~cursor=?,
     ~id=?,
     ~onlineStatuses=?,
-    ()
   ): refetchVariables => {
-    count: count,
-    cursor: cursor,
-    id: id,
-    onlineStatuses: onlineStatuses
+    count: ?count,
+    cursor: ?cursor,
+    id: ?id,
+    onlineStatuses: ?onlineStatuses
   }
 
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -63,7 +68,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -77,7 +82,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -91,7 +96,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -99,12 +104,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -113,27 +117,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~count: int=?,
-    ~cursor: string=?,
-    ~id: string,
-    ~onlineStatuses: array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>=?,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -202,10 +193,10 @@ v7 = [
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v3/*: any*/)
+      (v0),
+      (v1),
+      (v2),
+      (v3)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -213,13 +204,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v4),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
+          (v5),
           {
             "args": [
               {
@@ -251,30 +242,30 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v2/*: any*/)
+      (v0),
+      (v1),
+      (v3),
+      (v2)
     ],
     "kind": "Operation",
     "name": "TestPaginationInNodeRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v4),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v6/*: any*/),
+          (v5),
+          (v6),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v7),
                 "concreteType": "UserConnection",
                 "kind": "LinkedField",
                 "name": "friendsConnection",
@@ -296,7 +287,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v6),
                           {
                             "alias": null,
                             "args": null,
@@ -328,7 +319,7 @@ return {
                             ],
                             "storageKey": "friendsConnection(first:1)"
                           },
-                          (v5/*: any*/)
+                          (v5)
                         ],
                         "storageKey": null
                       },
@@ -372,7 +363,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v7),
                 "filters": [
                   "statuses"
                 ],
@@ -401,11 +392,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_friendsConnection_edges_node = {
     @live id: string,
@@ -33,7 +33,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -52,12 +52,12 @@ let connectionKey = "TestPaginationInNode_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus>>=?) => {
   let args = {"statuses": onlineStatuses}
   internal_makeConnectionId(connectionParentDataId, args)
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 
   @live
@@ -116,7 +116,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0)
       }
     ],
     "refetch": {
@@ -126,7 +126,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0)
       },
       "fragmentPathInResult": [
         "node"
@@ -170,7 +170,7 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v1/*: any*/),
+                (v1),
                 {
                   "args": null,
                   "kind": "FragmentSpread",
@@ -224,7 +224,7 @@ return {
       ],
       "storageKey": null
     },
-    (v1/*: any*/)
+    (v1)
   ],
   "type": "User",
   "abstractKey": null

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_friendsConnection = {
     totalCount: int,
@@ -27,7 +27,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -37,7 +37,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type response = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestPaginationUnion_query]>,
@@ -13,18 +13,26 @@ module Types = {
   type variables = {
     groupId: string,
   }
-  @live
-  type refetchVariables = {
-    groupId: option<string>,
-  }
-  @live let makeRefetchVariables = (
-    ~groupId=?,
-    ()
-  ): refetchVariables => {
+  @live let makeVariables = (
+    ~groupId: string,
+  ): variables => {
     groupId: groupId
   }
 
+  @live
+  type refetchVariables = {
+    groupId?: string,
+  }
+  @live let makeRefetchVariables = (
+    ~groupId=?,
+  ): refetchVariables => {
+    groupId: ?groupId
+  }
+
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -37,7 +45,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -51,7 +59,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -65,7 +73,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -73,18 +81,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: (
-    ~groupId: string,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -115,7 +117,7 @@ v2 = [
     "name": "first",
     "value": 2
   },
-  (v1/*: any*/)
+  (v1)
 ],
 v3 = {
   "alias": null,
@@ -140,14 +142,14 @@ v5 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestPaginationUnionQuery",
     "selections": [
       {
         "args": [
-          (v1/*: any*/)
+          (v1)
         ],
         "kind": "FragmentSpread",
         "name": "TestPaginationUnion_query"
@@ -158,13 +160,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestPaginationUnionQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2),
         "concreteType": "MemberConnection",
         "kind": "LinkedField",
         "name": "members",
@@ -196,11 +198,11 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/),
+                      (v3),
+                      (v4),
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v5),
                         "concreteType": "UserConnection",
                         "kind": "LinkedField",
                         "name": "friendsConnection",
@@ -223,7 +225,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
+                      (v3),
                       {
                         "alias": null,
                         "args": null,
@@ -233,7 +235,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v5),
                         "concreteType": "UserConnection",
                         "kind": "LinkedField",
                         "name": "adminsConnection",
@@ -255,8 +257,8 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
-                                  (v4/*: any*/)
+                                  (v3),
+                                  (v4)
                                 ],
                                 "storageKey": null
                               }
@@ -273,7 +275,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/)
+                      (v3)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -321,7 +323,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2),
         "filters": [
           "groupId",
           "onlineStatuses"
@@ -334,21 +336,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6b445dc55b0afc5f84e817a3301891f3",
+    "cacheID": "72bb6d31f6699c75cf4e0781a3d0b0e1",
     "id": null,
     "metadata": {},
     "name": "TestPaginationUnionQuery",
     "operationKind": "query",
-    "text": "query TestPaginationUnionQuery(\n  $groupId: ID!\n) {\n  ...TestPaginationUnion_query_3nceos\n}\n\nfragment TestPaginationUnion_query_3nceos on Query {\n  members(groupId: $groupId, first: 2, after: \"\") {\n    edges {\n      node {\n        __typename\n        ... on User {\n          id\n          ...TestPaginationUnion_user\n        }\n        ... on Group {\n          id\n          name\n          adminsConnection(first: 1) {\n            edges {\n              node {\n                id\n                firstName\n              }\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TestPaginationUnion_user on User {\n  firstName\n  friendsConnection(first: 1) {\n    totalCount\n  }\n}\n"
+    "text": "query TestPaginationUnionQuery(\n  $groupId: ID!\n) {\n  ...TestPaginationUnion_query_3nceos\n}\n\nfragment TestPaginationUnion_query_3nceos on Query {\n  members(groupId: $groupId, first: 2, after: \"\") {\n    edges {\n      node {\n        __typename\n        ... on User {\n          id\n          ...TestPaginationUnion_user\n        }\n        ... on Group {\n          id\n          name\n          adminsConnection(first: 1) {\n            edges {\n              node {\n                id\n                firstName\n              }\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TestPaginationUnion_user on User {\n  firstName\n  friendsConnection(first: 1) {\n    totalCount\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type response = {
@@ -12,40 +12,46 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    count: option<int>,
-    cursor: option<string>,
+    count?: int,
+    cursor?: string,
     groupId: string,
-    onlineStatuses: option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>,
+    onlineStatuses?: array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
+  @live let makeVariables = (
+    ~count=?,
+    ~cursor=?,
+    ~groupId: string,
+    ~onlineStatuses=?,
+  ): variables => {
+    count: ?count,
+    cursor: ?cursor,
+    groupId: groupId,
+    onlineStatuses: ?onlineStatuses
+  }
+
   @live
   type refetchVariables = {
-    count: option<option<int>>,
-    cursor: option<option<string>>,
-    groupId: option<string>,
-    onlineStatuses: option<option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>>,
+    count?: option<int>,
+    cursor?: option<string>,
+    groupId?: string,
+    onlineStatuses?: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>>,
   }
   @live let makeRefetchVariables = (
     ~count=?,
     ~cursor=?,
     ~groupId=?,
     ~onlineStatuses=?,
-    ()
   ): refetchVariables => {
-    count: count,
-    cursor: cursor,
-    groupId: groupId,
-    onlineStatuses: onlineStatuses
+    count: ?count,
+    cursor: ?cursor,
+    groupId: ?groupId,
+    onlineStatuses: ?onlineStatuses
   }
 
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -58,7 +64,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -72,7 +78,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -86,7 +92,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -94,12 +100,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -108,27 +113,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~count: int=?,
-    ~cursor: string=?,
-    ~groupId: string,
-    ~onlineStatuses: array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>=?,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -179,8 +171,8 @@ v3 = [
     "name": "first",
     "variableName": "count"
   },
-  (v1/*: any*/),
-  (v2/*: any*/)
+  (v1),
+  (v2)
 ],
 v4 = {
   "alias": null,
@@ -205,7 +197,7 @@ v6 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestPaginationUnionRefetchQuery",
@@ -222,8 +214,8 @@ return {
             "name": "cursor",
             "variableName": "cursor"
           },
-          (v1/*: any*/),
-          (v2/*: any*/)
+          (v1),
+          (v2)
         ],
         "kind": "FragmentSpread",
         "name": "TestPaginationUnion_query"
@@ -234,13 +226,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestPaginationUnionRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3),
         "concreteType": "MemberConnection",
         "kind": "LinkedField",
         "name": "members",
@@ -272,11 +264,11 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      (v4),
+                      (v5),
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v6),
                         "concreteType": "UserConnection",
                         "kind": "LinkedField",
                         "name": "friendsConnection",
@@ -299,7 +291,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v4/*: any*/),
+                      (v4),
                       {
                         "alias": null,
                         "args": null,
@@ -309,7 +301,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v6),
                         "concreteType": "UserConnection",
                         "kind": "LinkedField",
                         "name": "adminsConnection",
@@ -331,8 +323,8 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
-                                  (v5/*: any*/)
+                                  (v4),
+                                  (v5)
                                 ],
                                 "storageKey": null
                               }
@@ -349,7 +341,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v4/*: any*/)
+                      (v4)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -397,7 +389,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3),
         "filters": [
           "groupId",
           "onlineStatuses"
@@ -410,21 +402,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6af34d73805cda999d6b6988b06000ee",
+    "cacheID": "66615af413ef07d5369ef0bd94617e92",
     "id": null,
     "metadata": {},
     "name": "TestPaginationUnionRefetchQuery",
     "operationKind": "query",
-    "text": "query TestPaginationUnionRefetchQuery(\n  $count: Int = 2\n  $cursor: String = \"\"\n  $groupId: ID!\n  $onlineStatuses: [OnlineStatus!]\n) {\n  ...TestPaginationUnion_query_2z6KWr\n}\n\nfragment TestPaginationUnion_query_2z6KWr on Query {\n  members(groupId: $groupId, onlineStatuses: $onlineStatuses, first: $count, after: $cursor) {\n    edges {\n      node {\n        __typename\n        ... on User {\n          id\n          ...TestPaginationUnion_user\n        }\n        ... on Group {\n          id\n          name\n          adminsConnection(first: 1) {\n            edges {\n              node {\n                id\n                firstName\n              }\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TestPaginationUnion_user on User {\n  firstName\n  friendsConnection(first: 1) {\n    totalCount\n  }\n}\n"
+    "text": "query TestPaginationUnionRefetchQuery(\n  $count: Int = 2\n  $cursor: String = \"\"\n  $groupId: ID!\n  $onlineStatuses: [OnlineStatus!]\n) {\n  ...TestPaginationUnion_query_2z6KWr\n}\n\nfragment TestPaginationUnion_query_2z6KWr on Query {\n  members(groupId: $groupId, onlineStatuses: $onlineStatuses, first: $count, after: $cursor) {\n    edges {\n      node {\n        __typename\n        ... on User {\n          id\n          ...TestPaginationUnion_user\n        }\n        ... on Group {\n          id\n          name\n          adminsConnection(first: 1) {\n            edges {\n              node {\n                id\n                firstName\n              }\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TestPaginationUnion_user on User {\n  firstName\n  friendsConnection(first: 1) {\n    totalCount\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_members_edges_node_Group_adminsConnection_edges_node = {
     firstName: string,
@@ -14,22 +14,21 @@ module Types = {
   and fragment_members_edges_node_Group_adminsConnection = {
     edges: option<array<option<fragment_members_edges_node_Group_adminsConnection_edges>>>,
   }
-  and fragment_members_edges_node_Group = {
-    @live __typename: [ | #Group],
-    adminsConnection: fragment_members_edges_node_Group_adminsConnection,
-    @live id: string,
-    name: string,
-  }
-  and fragment_members_edges_node_User = {
-    @live __typename: [ | #User],
-    @live id: string,
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestPaginationUnion_user]>,
-  }
-  and fragment_members_edges_node = [
-    | #Group(fragment_members_edges_node_Group)
-    | #User(fragment_members_edges_node_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") and fragment_members_edges_node = 
+    | @live Group(
+      {
+        adminsConnection: fragment_members_edges_node_Group_adminsConnection,
+        @live id: string,
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        @as("TestPaginationUnion_user") testPaginationUnion_user: option<RescriptRelay.fragmentRefs<[ | #TestPaginationUnion_user]>>,
+        @live id: string,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type rec fragment_members_edges = {
     node: option<fragment_members_edges_node>,
@@ -43,32 +42,15 @@ module Types = {
 }
 
 @live
-let unwrap_fragment_members_edges_node: {. "__typename": string } => [
-  | #Group(Types.fragment_members_edges_node_Group)
-  | #User(Types.fragment_members_edges_node_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment_members_edges_node: Types.fragment_members_edges_node => Types.fragment_members_edges_node = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_fragment_members_edges_node: [
-  | #Group(Types.fragment_members_edges_node_Group)
-  | #User(Types.fragment_members_edges_node_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment_members_edges_node: Types.fragment_members_edges_node => Types.fragment_members_edges_node = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   type fragmentRaw
   @live
   let fragmentConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"members_edges_node_User":{"f":""},"members_edges_node":{"u":"fragment_members_edges_node"}}}`
+    json`{"__root":{"members_edges_node_User_testPaginationUnion_user":{"k":"TestPaginationUnion_user"},"members_edges_node_User_TestPaginationUnion_user":{"k":"testPaginationUnion_user"},"members_edges_node":{"u":"fragment_members_edges_node"}}}`
   )
   @live
   let fragmentConverterMap = {
@@ -78,7 +60,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -97,13 +79,13 @@ let connectionKey = "TestPaginationUnion_query_members"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~groupId: string, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~groupId: string, ~onlineStatuses: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus>>=?) => {
   let groupId = Some(groupId)
   let args = {"groupId": groupId, "onlineStatuses": onlineStatuses}
   internal_makeConnectionId(connectionParentDataId, args)
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 
   @live
@@ -171,7 +153,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0)
       }
     ],
     "refetch": {
@@ -181,7 +163,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0)
       },
       "fragmentPathInResult": [],
       "operation": rescript_graphql_node_TestPaginationUnionRefetchQuery
@@ -225,12 +207,30 @@ return {
               "plural": false,
               "selections": [
                 {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                },
+                {
                   "kind": "InlineFragment",
                   "selections": [
-                    (v1/*: any*/),
+                    (v1),
                     {
-                      "args": null,
-                      "kind": "FragmentSpread",
+                      "fragment": {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "TestPaginationUnion_user"
+                          }
+                        ],
+                        "type": "User",
+                        "abstractKey": null
+                      },
+                      "kind": "AliasedInlineFragmentSpread",
                       "name": "TestPaginationUnion_user"
                     }
                   ],
@@ -240,7 +240,7 @@ return {
                 {
                   "kind": "InlineFragment",
                   "selections": [
-                    (v1/*: any*/),
+                    (v1),
                     {
                       "alias": null,
                       "args": null,
@@ -278,7 +278,7 @@ return {
                               "name": "node",
                               "plural": false,
                               "selections": [
-                                (v1/*: any*/),
+                                (v1),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -298,13 +298,6 @@ return {
                   ],
                   "type": "Group",
                   "abstractKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "__typename",
-                  "storageKey": null
                 }
               ],
               "storageKey": null

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_friendsConnection = {
     totalCount: int,
@@ -26,7 +26,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -36,7 +36,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestProvidedVariablesQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestProvidedVariablesQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live type inputC = RelaySchemaAssets_graphql.input_InputC
   type rec response_loggedInUser = {
@@ -15,10 +15,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -33,7 +37,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -47,7 +51,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -61,7 +65,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -69,45 +73,36 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external make_inputC: (
-    ~intStr: TestsUtils.IntString.t,
-    ~recursiveC: inputC=?,
-    unit
-  ) => inputC = ""
-
-
-  @live @obj external makeVariables: unit => unit = ""
 }
-type providedVariable<'t> = { providedVariable: unit => 't, get: unit => 't }
-type providedVariablesType = {
+@live type providedVariable<'t> = { providedVariable: unit => 't, get: unit => 't }
+@live type providedVariablesType = {
   __relay_internal__pv__ProvidedVariablesBool: providedVariable<bool>,
   __relay_internal__pv__ProvidedVariablesInputC: providedVariable<RelaySchemaAssets_graphql.input_InputC>,
   __relay_internal__pv__ProvidedVariablesInputCArr: providedVariable<option<array<RelaySchemaAssets_graphql.input_InputC>>>,
   __relay_internal__pv__ProvidedVariablesIntStr: providedVariable<TestsUtils.IntString.t>,
 }
-let providedVariablesDefinition: providedVariablesType = {
+@live let providedVariablesDefinition: providedVariablesType = {
   __relay_internal__pv__ProvidedVariablesBool: {
     providedVariable: ProvidedVariables.Bool.get,
     get: ProvidedVariables.Bool.get,
   },
   __relay_internal__pv__ProvidedVariablesInputC: {
     providedVariable: ProvidedVariables.InputC.get,
-    get: () => Internal.convertVariables(Js.Dict.fromArray([("__relay_internal__pv__ProvidedVariablesInputC", ProvidedVariables.InputC.get())]))->Js.Dict.unsafeGet("__relay_internal__pv__ProvidedVariablesInputC"),
+    get: () => Internal.convertVariables(Js.Dict.fromArray([("__relay_internal__pv__ProvidedVariablesInputC", ProvidedVariables.InputC.get())]))->Js.Dict.get("__relay_internal__pv__ProvidedVariablesInputC")->Belt.Option.getExn,
   },
   __relay_internal__pv__ProvidedVariablesInputCArr: {
     providedVariable: ProvidedVariables.InputCArr.get,
-    get: () => Internal.convertVariables(Js.Dict.fromArray([("__relay_internal__pv__ProvidedVariablesInputCArr", ProvidedVariables.InputCArr.get())]))->Js.Dict.unsafeGet("__relay_internal__pv__ProvidedVariablesInputCArr"),
+    get: () => Internal.convertVariables(Js.Dict.fromArray([("__relay_internal__pv__ProvidedVariablesInputCArr", ProvidedVariables.InputCArr.get())]))->Js.Dict.get("__relay_internal__pv__ProvidedVariablesInputCArr")->Belt.Option.getExn,
   },
   __relay_internal__pv__ProvidedVariablesIntStr: {
     providedVariable: ProvidedVariables.IntStr.get,
-    get: () => Internal.convertVariables(Js.Dict.fromArray([("__relay_internal__pv__ProvidedVariablesIntStr", ProvidedVariables.IntStr.get())]))->Js.Dict.unsafeGet("__relay_internal__pv__ProvidedVariablesIntStr"),
+    get: () => Internal.convertVariables(Js.Dict.fromArray([("__relay_internal__pv__ProvidedVariablesIntStr", ProvidedVariables.IntStr.get())]))->Js.Dict.get("__relay_internal__pv__ProvidedVariablesIntStr")->Belt.Option.getExn,
   },
 }
 
@@ -232,11 +227,44 @@ type operationType = RescriptRelay.queryNode<relayOperationNode>
 })
 let node: operationType = makeNode(providedVariablesDefinition)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestProvidedVariables_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestProvidedVariables_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     someRandomArgField: option<string>,
@@ -22,7 +22,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -32,7 +32,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestProvidedVariables_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestQueryInputObjectsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestQueryInputObjectsQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live type searchInput = RelaySchemaAssets_graphql.input_SearchInput
   type response = {
@@ -14,18 +14,26 @@ module Types = {
   type variables = {
     input: searchInput,
   }
-  @live
-  type refetchVariables = {
-    input: option<searchInput>,
-  }
-  @live let makeRefetchVariables = (
-    ~input=?,
-    ()
-  ): refetchVariables => {
+  @live let makeVariables = (
+    ~input: searchInput,
+  ): variables => {
     input: input
   }
 
+  @live
+  type refetchVariables = {
+    input?: searchInput,
+  }
+  @live let makeRefetchVariables = (
+    ~input=?,
+  ): refetchVariables => {
+    input: ?input
+  }
+
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -38,7 +46,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -52,7 +60,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -66,7 +74,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -74,26 +82,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external make_searchInput: (
-    ~id: int,
-    ~names: array<option<string>>=?,
-    ~someOtherId: float=?,
-    unit
-  ) => searchInput = ""
-
-
-  @live @obj external makeVariables: (
-    ~input: searchInput,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -125,20 +119,20 @@ v1 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestQueryInputObjectsQuery",
-    "selections": (v1/*: any*/),
+    "selections": (v1),
     "type": "Query",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestQueryInputObjectsQuery",
-    "selections": (v1/*: any*/)
+    "selections": (v1)
   },
   "params": {
     "cacheID": "8441859dad587e683a224cfc73959cdc",
@@ -151,11 +145,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_users_edges_node = {
     firstName: string,
@@ -22,28 +22,28 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    status: option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>,
+    status?: RelaySchemaAssets_graphql.enum_OnlineStatus_input,
   }
+  @live let makeVariables = (
+    ~status=?,
+  ): variables => {
+    status: ?status
+  }
+
   @live
   type refetchVariables = {
-    status: option<option<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>,
+    status?: option<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
   }
   @live let makeRefetchVariables = (
     ~status=?,
-    ()
   ): refetchVariables => {
-    status: status
+    status: ?status
   }
 
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -56,7 +56,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -70,7 +70,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -84,7 +84,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -92,12 +92,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -106,24 +105,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~status: [
-      | #Idle
-      | #Offline
-      | #Online
-    ]=?,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -202,20 +191,20 @@ v1 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestQuery",
-    "selections": (v1/*: any*/),
+    "selections": (v1),
     "type": "Query",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestQuery",
-    "selections": (v1/*: any*/)
+    "selections": (v1)
   },
   "params": {
     "cacheID": "123064f3c998fd5b717ca05be99d7ee1",
@@ -228,11 +217,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.res
@@ -2,12 +2,16 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_node = {
-    @live __typename: [ | #User],
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestRefetchingInNode_user]>,
-  }
+  @tag("__typename") type response_node = 
+    | @live User(
+      {
+        @as("TestRefetchingInNode_user") testRefetchingInNode_user: option<RescriptRelay.fragmentRefs<[ | #TestRefetchingInNode_user]>>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
+
   type response = {
     node: option<response_node>,
   }
@@ -15,32 +19,38 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    friendsOnlineStatuses: option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>,
+    friendsOnlineStatuses?: array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
     userId: string,
   }
+  @live let makeVariables = (
+    ~friendsOnlineStatuses=?,
+    ~userId: string,
+  ): variables => {
+    friendsOnlineStatuses: ?friendsOnlineStatuses,
+    userId: userId
+  }
+
   @live
   type refetchVariables = {
-    friendsOnlineStatuses: option<option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>>,
-    userId: option<string>,
+    friendsOnlineStatuses?: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>>,
+    userId?: string,
   }
   @live let makeRefetchVariables = (
     ~friendsOnlineStatuses=?,
     ~userId=?,
-    ()
   ): refetchVariables => {
-    friendsOnlineStatuses: friendsOnlineStatuses,
-    userId: userId
+    friendsOnlineStatuses: ?friendsOnlineStatuses,
+    userId: ?userId
   }
 
 }
+
+@live
+let unwrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.unwrapUnion(_, ["User"])
+@live
+let wrap_response_node: Types.response_node => Types.response_node = RescriptRelay_Internal.wrapUnion
+
+type queryRef
 
 module Internal = {
   @live
@@ -53,35 +63,39 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
   @live
   let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User","f":""}}}`
+    json`{"__root":{"node_User_testRefetchingInNode_user":{"k":"TestRefetchingInNode_user"},"node_User_TestRefetchingInNode_user":{"k":"testRefetchingInNode_user"},"node":{"u":"response_node"}}}`
   )
   @live
-  let wrapResponseConverterMap = ()
+  let wrapResponseConverterMap = {
+    "response_node": wrap_response_node,
+  }
   @live
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
   @live
   let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"node":{"tnf":"User","f":""}}}`
+    json`{"__root":{"node_User_testRefetchingInNode_user":{"k":"TestRefetchingInNode_user"},"node_User_TestRefetchingInNode_user":{"k":"testRefetchingInNode_user"},"node":{"u":"response_node"}}}`
   )
   @live
-  let responseConverterMap = ()
+  let responseConverterMap = {
+    "response_node": unwrap_response_node,
+  }
   @live
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -89,12 +103,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -103,25 +116,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~friendsOnlineStatuses: array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>=?,
-    ~userId: string,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -156,8 +158,8 @@ v3 = {
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
+      (v0),
+      (v1)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -165,25 +167,36 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v3),
           {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "friendsOnlineStatuses",
-                    "variableName": "friendsOnlineStatuses"
-                  }
-                ],
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": [
+                        {
+                          "kind": "Variable",
+                          "name": "friendsOnlineStatuses",
+                          "variableName": "friendsOnlineStatuses"
+                        }
+                      ],
+                      "kind": "FragmentSpread",
+                      "name": "TestRefetchingInNode_user"
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "TestRefetchingInNode_user"
               }
             ],
@@ -200,21 +213,21 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
+      (v1),
+      (v0)
     ],
     "kind": "Operation",
     "name": "TestRefetchingInNodeQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v3),
           {
             "alias": null,
             "args": null,
@@ -276,11 +289,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.res
@@ -2,11 +2,10 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_node = {
-    @live __typename: string,
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestRefetchingInNode_user]>,
   }
   @live
@@ -17,36 +16,40 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    friendsOnlineStatuses: option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>,
+    friendsOnlineStatuses?: array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
     @live id: string,
-    showOnlineStatus: option<bool>,
+    showOnlineStatus?: bool,
   }
+  @live let makeVariables = (
+    ~friendsOnlineStatuses=?,
+    ~id: string,
+    ~showOnlineStatus=?,
+  ): variables => {
+    friendsOnlineStatuses: ?friendsOnlineStatuses,
+    id: id,
+    showOnlineStatus: ?showOnlineStatus
+  }
+
   @live
   type refetchVariables = {
-    friendsOnlineStatuses: option<option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>>,
-    @live id: option<string>,
-    showOnlineStatus: option<option<bool>>,
+    friendsOnlineStatuses?: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>>,
+    @live id?: string,
+    showOnlineStatus?: option<bool>,
   }
   @live let makeRefetchVariables = (
     ~friendsOnlineStatuses=?,
     ~id=?,
     ~showOnlineStatus=?,
-    ()
   ): refetchVariables => {
-    friendsOnlineStatuses: friendsOnlineStatuses,
-    id: id,
-    showOnlineStatus: showOnlineStatus
+    friendsOnlineStatuses: ?friendsOnlineStatuses,
+    id: ?id,
+    showOnlineStatus: ?showOnlineStatus
   }
 
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -59,7 +62,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -73,7 +76,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -87,7 +90,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -95,12 +98,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -109,26 +111,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~friendsOnlineStatuses: array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>=?,
-    ~id: string,
-    ~showOnlineStatus: bool=?,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -168,9 +158,9 @@ v4 = {
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/)
+      (v0),
+      (v1),
+      (v2)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -178,13 +168,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v4),
           {
             "args": [
               {
@@ -211,22 +201,22 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v2/*: any*/),
-      (v1/*: any*/)
+      (v0),
+      (v2),
+      (v1)
     ],
     "kind": "Operation",
     "name": "TestRefetchingInNodeRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v4),
           {
             "alias": null,
             "args": null,
@@ -302,11 +292,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_friendsConnection = {
     totalCount: int,
@@ -28,7 +28,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -38,7 +38,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingInNode_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -47,8 +47,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingNoArgsRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingNoArgsRefetchQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type response = {
@@ -12,10 +12,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -28,7 +32,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -42,7 +46,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -56,7 +60,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -64,14 +68,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -130,11 +132,44 @@ let node: operationType = %raw(json` {
   }
 } `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingNoArgs_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingNoArgs_query_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_loggedInUser = {
     @live id: string,
@@ -25,7 +25,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -35,7 +35,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingNoArgs_query]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestRefetching_user]>,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -168,11 +170,44 @@ let node: operationType = %raw(json` {
   }
 } `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.res
@@ -2,11 +2,10 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_node = {
-    @live __typename: string,
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestRefetching_user]>,
   }
   @live
@@ -17,36 +16,40 @@ module Types = {
   type rawResponse = response
   @live
   type variables = {
-    friendsOnlineStatuses: option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>,
+    friendsOnlineStatuses?: array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>,
     @live id: string,
-    showOnlineStatus: option<bool>,
+    showOnlineStatus?: bool,
   }
+  @live let makeVariables = (
+    ~friendsOnlineStatuses=?,
+    ~id: string,
+    ~showOnlineStatus=?,
+  ): variables => {
+    friendsOnlineStatuses: ?friendsOnlineStatuses,
+    id: id,
+    showOnlineStatus: ?showOnlineStatus
+  }
+
   @live
   type refetchVariables = {
-    friendsOnlineStatuses: option<option<array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>>>,
-    @live id: option<string>,
-    showOnlineStatus: option<option<bool>>,
+    friendsOnlineStatuses?: option<array<RelaySchemaAssets_graphql.enum_OnlineStatus_input>>,
+    @live id?: string,
+    showOnlineStatus?: option<bool>,
   }
   @live let makeRefetchVariables = (
     ~friendsOnlineStatuses=?,
     ~id=?,
     ~showOnlineStatus=?,
-    ()
   ): refetchVariables => {
-    friendsOnlineStatuses: friendsOnlineStatuses,
-    id: id,
-    showOnlineStatus: showOnlineStatus
+    friendsOnlineStatuses: ?friendsOnlineStatuses,
+    id: ?id,
+    showOnlineStatus: ?showOnlineStatus
   }
 
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -59,7 +62,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -73,7 +76,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -87,7 +90,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -95,12 +98,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -109,26 +111,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~friendsOnlineStatuses: array<[
-      | #Idle
-      | #Offline
-      | #Online
-    ]>=?,
-    ~id: string,
-    ~showOnlineStatus: bool=?,
-    unit
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -168,9 +158,9 @@ v4 = {
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/)
+      (v0),
+      (v1),
+      (v2)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -178,13 +168,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v4),
           {
             "args": [
               {
@@ -211,22 +201,22 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v2/*: any*/),
-      (v1/*: any*/)
+      (v0),
+      (v2),
+      (v1)
     ],
     "kind": "Operation",
     "name": "TestRefetchingRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v4),
           {
             "alias": null,
             "args": null,
@@ -302,11 +292,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec fragment_friendsConnection = {
     totalCount: int,
@@ -28,7 +28,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -38,7 +38,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetching_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -47,8 +47,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestRelayResolversQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRelayResolversQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestRelayResolvers_user]>,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -154,7 +156,7 @@ let node: operationType = %raw(json` {
             },
             "kind": "RelayResolver",
             "storageKey": null,
-            "isOutputType": false
+            "isOutputType": true
           },
           {
             "alias": null,
@@ -178,11 +180,44 @@ let node: operationType = %raw(json` {
   }
 } `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestRelayResolvers_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRelayResolvers_user_graphql.res
@@ -2,10 +2,10 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
-    fullName: option<TestRelayUserResolver.t>,
+    fullName: option<string>,
     isOnline: option<bool>,
   }
 }
@@ -23,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -33,7 +33,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayResolvers_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 
@@ -41,8 +41,9 @@ type relayOperationNode
 type operationType = RescriptRelay.fragmentNode<relayOperationNode>
 
 
-%%private(let makeNode = (rescript_module_TestRelayUserResolver): operationType => {
-  ignore(rescript_module_TestRelayUserResolver)
+%%private(let makeNode = (resolverDataInjector, rescript_module_TestRelayUserResolver_fullName): operationType => {
+  ignore(resolverDataInjector)
+  ignore(rescript_module_TestRelayUserResolver_fullName)
   %raw(json`{
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -66,7 +67,7 @@ type operationType = RescriptRelay.fragmentNode<relayOperationNode>
       },
       "kind": "RelayResolver",
       "name": "fullName",
-      "resolverModule": rescript_module_TestRelayUserResolver,
+      "resolverModule": rescript_module_TestRelayUserResolver_fullName,
       "path": "fullName"
     }
   ],
@@ -74,5 +75,5 @@ type operationType = RescriptRelay.fragmentNode<relayOperationNode>
   "abstractKey": null
 }`)
 })
-let node: operationType = makeNode(TestRelayUserResolver.default)
+let node: operationType = makeNode(RescriptRelay.resolverDataInjector, TestRelayUserResolver.fullName)
 

--- a/packages/rescript-relay/__tests__/__generated__/TestRelayUserResolver_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRelayUserResolver_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     firstName: string,
@@ -23,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -33,7 +33,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayUserResolver]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
 }
 

--- a/packages/rescript-relay/__tests__/__generated__/TestRequiredFieldLoggerQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRequiredFieldLoggerQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     firstName: string,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -105,9 +107,8 @@ return {
         "selections": [
           {
             "kind": "RequiredField",
-            "field": (v0/*: any*/),
-            "action": "LOG",
-            "path": "loggedInUser.firstName"
+            "field": (v0),
+            "action": "LOG"
           }
         ],
         "storageKey": null
@@ -130,7 +131,7 @@ return {
         "name": "loggedInUser",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
+          (v0),
           {
             "alias": null,
             "args": null,
@@ -154,11 +155,44 @@ return {
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscriptionQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscriptionQuery_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_loggedInUser = {
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestSubscription_user]>,
@@ -14,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -30,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -44,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -58,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -66,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -164,11 +166,44 @@ let node: operationType = %raw(json` {
   }
 } `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   @live
   type rec response_userUpdated_user = {
@@ -24,6 +24,12 @@ module Types = {
   type variables = {
     userId: string,
   }
+  @live let makeVariables = (
+    ~userId: string,
+  ): variables => {
+    userId: userId
+  }
+
 }
 
 module Internal = {
@@ -37,7 +43,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type responseRaw
@@ -51,14 +57,14 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
 }
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -67,19 +73,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: (
-    ~userId: string,
-  ) => variables = ""
-
-
 }
 
 type relayOperationNode
@@ -117,14 +118,14 @@ v3 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestSubscriptionUserUpdatedSubscription",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "UserUpdatedPayload",
         "kind": "LinkedField",
         "name": "userUpdated",
@@ -138,8 +139,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2),
+              (v3),
               {
                 "args": null,
                 "kind": "FragmentSpread",
@@ -157,13 +158,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0),
     "kind": "Operation",
     "name": "TestSubscriptionUserUpdatedSubscription",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1),
         "concreteType": "UserUpdatedPayload",
         "kind": "LinkedField",
         "name": "userUpdated",
@@ -177,8 +178,8 @@ return {
             "name": "user",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2),
+              (v3),
               {
                 "alias": null,
                 "args": null,

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscription_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscription_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     avatarUrl: option<string>,
@@ -25,7 +25,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -35,7 +35,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestSubscription_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -44,8 +44,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentQuery_graphql.res
@@ -2,10 +2,9 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type rec response_member = {
-    @live __typename: string,
     fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestUnionFragment_member | #TestUnionFragment_plural_member]>,
   }
   type response = {
@@ -15,10 +14,14 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
+
+
+type queryRef
 
 module Internal = {
   @live
@@ -31,7 +34,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -45,7 +48,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -59,7 +62,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -67,14 +70,12 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -105,13 +106,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "member",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -137,13 +138,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "member",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v1),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isMember"
@@ -203,21 +204,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "21ff5bfa26571b6c0dd392207d7bf454",
+    "cacheID": "e3338849612371520f3e4c24e857d5a9",
     "id": null,
     "metadata": {},
     "name": "TestUnionFragmentQuery",
     "operationKind": "query",
-    "text": "query TestUnionFragmentQuery {\n  member(id: \"123\") {\n    __typename\n    ...TestUnionFragment_member\n    ...TestUnionFragment_plural_member\n    ... on Node {\n      __isNode: __typename\n      __typename\n      id\n    }\n  }\n}\n\nfragment TestUnionFragmentUser_user on User {\n  firstName\n  onlineStatus\n}\n\nfragment TestUnionFragment_member on Member {\n  __isMember: __typename\n  __typename\n  ... on User {\n    firstName\n    onlineStatus\n    ...TestUnionFragmentUser_user\n  }\n  ... on Group {\n    name\n  }\n}\n\nfragment TestUnionFragment_plural_member on Member {\n  __isMember: __typename\n  __typename\n  ... on User {\n    firstName\n    onlineStatus\n    ...TestUnionFragmentUser_user\n  }\n  ... on Group {\n    name\n  }\n}\n"
+    "text": "query TestUnionFragmentQuery {\n  member(id: \"123\") {\n    __typename\n    ...TestUnionFragment_member\n    ...TestUnionFragment_plural_member\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment TestUnionFragmentUser_user on User {\n  firstName\n  onlineStatus\n}\n\nfragment TestUnionFragment_member on Member {\n  __isMember: __typename\n  ... on User {\n    firstName\n    onlineStatus\n    ...TestUnionFragmentUser_user\n  }\n  ... on Group {\n    name\n  }\n}\n\nfragment TestUnionFragment_plural_member on Member {\n  __isMember: __typename\n  ... on User {\n    firstName\n    onlineStatus\n    ...TestUnionFragmentUser_user\n  }\n  ... on Group {\n    name\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentUser_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentUser_user_graphql.res
@@ -2,7 +2,7 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
   type fragment = {
     firstName: string,
@@ -23,7 +23,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -33,7 +33,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUnionFragmentUser_user]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -42,8 +42,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_member_graphql.res
@@ -2,53 +2,35 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec fragment_Group = {
-    @live __typename: [ | #Group],
-    name: string,
-  }
-  and fragment_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestUnionFragmentUser_user]>,
-  }
-  type fragment = [
-    | #Group(fragment_Group)
-    | #User(fragment_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type fragment = 
+    | @live Group(
+      {
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        @as("TestUnionFragmentUser_user") testUnionFragmentUser_user: option<RescriptRelay.fragmentRefs<[ | #TestUnionFragmentUser_user]>>,
+        firstName: string,
+        onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
 }
 
 @live
-let unwrap_fragment: {. "__typename": string } => [
-  | #Group(Types.fragment_Group)
-  | #User(Types.fragment_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment: Types.fragment => Types.fragment = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_fragment: [
-  | #Group(Types.fragment_Group)
-  | #User(Types.fragment_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment: Types.fragment => Types.fragment = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   type fragmentRaw
   @live
   let fragmentConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"User":{"f":""},"":{"u":"fragment"}}}`
+    json`{"__root":{"User_testUnionFragmentUser_user":{"k":"TestUnionFragmentUser_user"},"User_TestUnionFragmentUser_user":{"k":"testUnionFragmentUser_user"},"":{"u":"fragment"}}}`
   )
   @live
   let fragmentConverterMap = {
@@ -58,7 +40,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -68,7 +50,7 @@ external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUnionFragment_member]> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -77,8 +59,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
@@ -122,8 +104,19 @@ let node: operationType = %raw(json` {
           "storageKey": null
         },
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TestUnionFragmentUser_user"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "TestUnionFragmentUser_user"
         }
       ],

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.res
@@ -2,54 +2,36 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec fragment_Group = {
-    @live __typename: [ | #Group],
-    name: string,
-  }
-  and fragment_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestUnionFragmentUser_user]>,
-  }
-  type fragment_t = [
-    | #Group(fragment_Group)
-    | #User(fragment_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type fragment_t = 
+    | @live Group(
+      {
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        @as("TestUnionFragmentUser_user") testUnionFragmentUser_user: option<RescriptRelay.fragmentRefs<[ | #TestUnionFragmentUser_user]>>,
+        firstName: string,
+        onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type fragment = array<fragment_t>
 }
 
 @live
-let unwrap_fragment: {. "__typename": string } => [
-  | #Group(Types.fragment_Group)
-  | #User(Types.fragment_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
-
+let unwrap_fragment: Types.fragment => Types.fragment = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
 @live
-let wrap_fragment: [
-  | #Group(Types.fragment_Group)
-  | #User(Types.fragment_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
+let wrap_fragment: Types.fragment => Types.fragment = RescriptRelay_Internal.wrapUnion
 module Internal = {
   @live
   type fragmentRaw
   @live
   let fragmentConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"User":{"f":""},"":{"u":"fragment"}}}`
+    json`{"__root":{"User_testUnionFragmentUser_user":{"k":"TestUnionFragmentUser_user"},"User_TestUnionFragmentUser_user":{"k":"testUnionFragmentUser_user"},"":{"u":"fragment"}}}`
   )
   @live
   let fragmentConverterMap = {
@@ -59,7 +41,7 @@ module Internal = {
   let convertFragment = v => v->RescriptRelay.convertObj(
     fragmentConverter,
     fragmentConverterMap,
-    Js.undefined
+    None
   )
 }
 
@@ -69,7 +51,7 @@ external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestUnionFragment_plural_member]>> => fragmentRef = "%identity"
 
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -78,8 +60,8 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
@@ -125,8 +107,19 @@ let node: operationType = %raw(json` {
           "storageKey": null
         },
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TestUnionFragmentUser_user"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "TestUnionFragmentUser_user"
         }
       ],

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionsQuery_graphql.res
@@ -2,44 +2,42 @@
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
-  @@ocaml.warning("-30")
+  @@warning("-30")
 
-  type rec response_members_edges_node_Group_members_Group = {
-    @live __typename: [ | #Group],
-    avatarUrl: option<string>,
-    @live id: string,
-    name: string,
-  }
-  and response_members_edges_node_Group_members_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-    @live id: string,
-    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
-  }
-  and response_members_edges_node_Group = {
-    @live __typename: [ | #Group],
-    avatarUrl: option<string>,
-    @live id: string,
-    members: option<array<option<response_members_edges_node_Group_members>>>,
-    name: string,
-  }
-  and response_members_edges_node_User = {
-    @live __typename: [ | #User],
-    firstName: string,
-    @live id: string,
-    onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
-  }
-  and response_members_edges_node_Group_members = [
-    | #Group(response_members_edges_node_Group_members_Group)
-    | #User(response_members_edges_node_Group_members_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type response_members_edges_node_Group_members = 
+    | @live Group(
+      {
+        avatarUrl: option<string>,
+        @live id: string,
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        firstName: string,
+        @live id: string,
+        onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
-  and response_members_edges_node = [
-    | #Group(response_members_edges_node_Group)
-    | #User(response_members_edges_node_User)
-    | #UnselectedUnionMember(string)
-  ]
+  @tag("__typename") type response_members_edges_node = 
+    | @live Group(
+      {
+        avatarUrl: option<string>,
+        @live id: string,
+        members: option<array<option<response_members_edges_node_Group_members>>>,
+        name: string,
+      }
+    )
+    | @live User(
+      {
+        firstName: string,
+        @live id: string,
+        onlineStatus: option<RelaySchemaAssets_graphql.enum_OnlineStatus>,
+      }
+    )
+    | @live @as("__unselected") UnselectedUnionMember(string)
 
   type rec response_members_edges = {
     node: option<response_members_edges_node>,
@@ -54,53 +52,23 @@ module Types = {
   type rawResponse = response
   @live
   type variables = unit
+  @live let makeVariables = () => ()
   @live
   type refetchVariables = unit
   @live let makeRefetchVariables = () => ()
 }
 
 @live
-let unwrap_response_members_edges_node_Group_members: {. "__typename": string } => [
-  | #Group(Types.response_members_edges_node_Group_members_Group)
-  | #User(Types.response_members_edges_node_Group_members_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
+let unwrap_response_members_edges_node_Group_members: Types.response_members_edges_node_Group_members => Types.response_members_edges_node_Group_members = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
+@live
+let wrap_response_members_edges_node_Group_members: Types.response_members_edges_node_Group_members => Types.response_members_edges_node_Group_members = RescriptRelay_Internal.wrapUnion
+@live
+let unwrap_response_members_edges_node: Types.response_members_edges_node => Types.response_members_edges_node = RescriptRelay_Internal.unwrapUnion(_, ["Group", "User"])
+@live
+let wrap_response_members_edges_node: Types.response_members_edges_node => Types.response_members_edges_node = RescriptRelay_Internal.wrapUnion
 
-@live
-let wrap_response_members_edges_node_Group_members: [
-  | #Group(Types.response_members_edges_node_Group_members_Group)
-  | #User(Types.response_members_edges_node_Group_members_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
-@live
-let unwrap_response_members_edges_node: {. "__typename": string } => [
-  | #Group(Types.response_members_edges_node_Group)
-  | #User(Types.response_members_edges_node_User)
-  | #UnselectedUnionMember(string)
-] = u => switch u["__typename"] {
-  | "Group" => #Group(u->Obj.magic)
-  | "User" => #User(u->Obj.magic)
-  | v => #UnselectedUnionMember(v)
-}
+type queryRef
 
-@live
-let wrap_response_members_edges_node: [
-  | #Group(Types.response_members_edges_node_Group)
-  | #User(Types.response_members_edges_node_User)
-  | #UnselectedUnionMember(string)
-] => {. "__typename": string } = v => switch v {
-  | #Group(v) => v->Obj.magic
-  | #User(v) => v->Obj.magic
-  | #UnselectedUnionMember(v) => {"__typename": v}
-}
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
@@ -112,7 +80,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    None
   )
   @live
   type wrapResponseRaw
@@ -129,7 +97,7 @@ module Internal = {
   let convertWrapResponse = v => v->RescriptRelay.convertObj(
     wrapResponseConverter,
     wrapResponseConverterMap,
-    Js.null
+    Js.Nullable.null
   )
   @live
   type responseRaw
@@ -146,7 +114,7 @@ module Internal = {
   let convertResponse = v => v->RescriptRelay.convertObj(
     responseConverter,
     responseConverterMap,
-    Js.undefined
+    None
   )
   type wrapRawResponseRaw = wrapResponseRaw
   @live
@@ -154,12 +122,11 @@ module Internal = {
   type rawResponseRaw = responseRaw
   @live
   let convertRawResponse = convertResponse
+  type rawPreloadToken<'response> = {source: Js.Nullable.t<RescriptRelay.Observable.t<'response>>}
+  external tokenToRaw: queryRef => rawPreloadToken<Types.response> = "%identity"
 }
-
-type queryRef
-
 module Utils = {
-  @@ocaml.warning("-33")
+  @@warning("-33")
   open Types
   @live
   external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
@@ -168,15 +135,14 @@ module Utils = {
   @live
   let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
-      | _ => None
+      | FutureAddedValue(_) => None
+      | valid => Some(Obj.magic(valid))
     }
   }
   @live
   let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
-  @live @obj external makeVariables: unit => unit = ""
 }
 
 type relayOperationNode
@@ -208,7 +174,7 @@ v2 = {
 v3 = {
   "kind": "InlineFragment",
   "selections": [
-    (v2/*: any*/),
+    (v2),
     {
       "alias": null,
       "args": null,
@@ -244,9 +210,9 @@ v5 = {
 v6 = {
   "kind": "InlineFragment",
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2),
+    (v4),
+    (v5)
   ],
   "type": "Group",
   "abstractKey": null
@@ -254,7 +220,7 @@ v6 = {
 v7 = {
   "kind": "InlineFragment",
   "selections": [
-    (v2/*: any*/)
+    (v2)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -268,7 +234,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": "MemberConnection",
         "kind": "LinkedField",
         "name": "members",
@@ -290,14 +256,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v1/*: any*/),
-                  (v3/*: any*/),
+                  (v1),
+                  (v3),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v2/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      (v2),
+                      (v4),
+                      (v5),
                       {
                         "alias": null,
                         "args": null,
@@ -306,9 +272,9 @@ return {
                         "name": "members",
                         "plural": true,
                         "selections": [
-                          (v1/*: any*/),
-                          (v3/*: any*/),
-                          (v6/*: any*/)
+                          (v1),
+                          (v3),
+                          (v6)
                         ],
                         "storageKey": null
                       }
@@ -337,7 +303,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v0/*: any*/),
+        "args": (v0),
         "concreteType": "MemberConnection",
         "kind": "LinkedField",
         "name": "members",
@@ -359,14 +325,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v1/*: any*/),
-                  (v3/*: any*/),
+                  (v1),
+                  (v3),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v2/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      (v2),
+                      (v4),
+                      (v5),
                       {
                         "alias": null,
                         "args": null,
@@ -375,10 +341,10 @@ return {
                         "name": "members",
                         "plural": true,
                         "selections": [
-                          (v1/*: any*/),
-                          (v3/*: any*/),
-                          (v6/*: any*/),
-                          (v7/*: any*/)
+                          (v1),
+                          (v3),
+                          (v6),
+                          (v7)
                         ],
                         "storageKey": null
                       }
@@ -386,7 +352,7 @@ return {
                     "type": "Group",
                     "abstractKey": null
                   },
-                  (v7/*: any*/)
+                  (v7)
                 ],
                 "storageKey": null
               }
@@ -399,21 +365,54 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7796bda6800b2da0ffac4f5a3b38b745",
+    "cacheID": "464cf1fe26e84aecf1d63a8c3837206c",
     "id": null,
     "metadata": {},
     "name": "TestUnionsQuery",
     "operationKind": "query",
-    "text": "query TestUnionsQuery {\n  members(groupId: \"123\") {\n    edges {\n      node {\n        __typename\n        ... on User {\n          id\n          firstName\n          onlineStatus\n        }\n        ... on Group {\n          id\n          name\n          avatarUrl\n          members {\n            __typename\n            ... on User {\n              id\n              firstName\n              onlineStatus\n            }\n            ... on Group {\n              id\n              name\n              avatarUrl\n            }\n            ... on Node {\n              __isNode: __typename\n              __typename\n              id\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query TestUnionsQuery {\n  members(groupId: \"123\") {\n    edges {\n      node {\n        __typename\n        ... on User {\n          id\n          firstName\n          onlineStatus\n        }\n        ... on Group {\n          id\n          name\n          avatarUrl\n          members {\n            __typename\n            ... on User {\n              id\n              firstName\n              onlineStatus\n            }\n            ... on Group {\n              id\n              name\n              avatarUrl\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })() `)
 
-include RescriptRelay.MakeLoadQuery({
-    type variables = Types.variables
-    type loadedQueryRef = queryRef
-    type response = Types.response
-    type node = relayOperationNode
-    let query = node
-    let convertVariables = Internal.convertVariables
-});
+@live let load: (
+  ~environment: RescriptRelay.Environment.t,
+  ~variables: Types.variables,
+  ~fetchPolicy: RescriptRelay.fetchPolicy=?,
+  ~fetchKey: string=?,
+  ~networkCacheConfig: RescriptRelay.cacheConfig=?,
+) => queryRef = (
+  ~environment,
+  ~variables,
+  ~fetchPolicy=?,
+  ~fetchKey=?,
+  ~networkCacheConfig=?,
+) =>
+  RescriptRelay.loadQuery(
+    environment,
+    node,
+    variables->Internal.convertVariables,
+    {
+      fetchKey,
+      fetchPolicy,
+      networkCacheConfig,
+    },
+  )
+
+@live
+let queryRefToObservable = token => {
+  let raw = token->Internal.tokenToRaw
+  raw.source->Js.Nullable.toOption
+}
+  
+@live
+let queryRefToPromise = token => {
+  Js.Promise.make((~resolve, ~reject as _) => {
+    switch token->queryRefToObservable {
+    | None => resolve(Error())
+    | Some(o) =>
+      open RescriptRelay.Observable
+      let _: subscription = o->subscribe(makeObserver(~complete=() => resolve(Ok()), ()))
+    }
+  })
+}

--- a/packages/rescript-relay/__tests__/__generated__/User_relayResolvers_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/User_relayResolvers_graphql.res
@@ -1,0 +1,5 @@
+/* @generated */
+@@warning("-30")
+
+type fullNameResolver = (RescriptRelay.resolverFragmentRefs<[#TestRelayUserResolver]>, ) => string
+

--- a/packages/rescript-relay/relay.config.js
+++ b/packages/rescript-relay/relay.config.js
@@ -3,14 +3,11 @@ module.exports = {
   artifactDirectory: "./__tests__/__generated__",
   src: "./__tests__",
   language: "rescript",
-  customScalars: {
+  customScalarTypes: {
     Datetime: "TestsUtils.Datetime",
     IntString: "TestsUtils.IntString",
     JSON: "Js.Json.t",
     Number: "TestsUtils.Number",
-  },
-  featureFlags: {
-    enable_relay_resolver_transform: true,
   },
   schemaExtensions: ["./__tests__"],
 };

--- a/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
@@ -98,14 +98,6 @@ let make ~loc ~moduleName ~refetchableQueryName ~extractedConnectionInfo
                           (fRef
                           |. [%e valFromGeneratedModule ["getFragmentRef"]])
                         ~node:[%e valFromGeneratedModule ["node"]]];
-                  [%stri
-                    let useBlockingPagination fRef =
-                      RescriptRelay_Fragment.useBlockingPaginationFragment
-                        ~convertFragment ~convertRefetchVariables
-                        ~fRef:
-                          (fRef
-                          |. [%e valFromGeneratedModule ["getFragmentRef"]])
-                        ~node:[%e valFromGeneratedModule ["node"]]];
                 ]
               else []);
           ]

--- a/packages/rescript-relay/src/RescriptRelay.res
+++ b/packages/rescript-relay/src/RescriptRelay.res
@@ -9,6 +9,7 @@ type mutationNode<'node>
 type subscriptionNode<'node>
 
 type fragmentRefs<'fragments>
+type resolverFragmentRefs<'fragments> = fragmentRefs<'fragments>
 
 type dataId
 type recordSourceRecords = Js.Json.t
@@ -72,6 +73,9 @@ external relayFeatureFlags: featureFlags = "RelayFeatureFlags"
 
 @module("./utils")
 external convertObj: ('a, Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>>, 'b, 'c) => 'd = "traverser"
+
+@module("relay-runtime/experimental")
+external resolverDataInjector: 'resolverDataInjector = "resolverDataInjector"
 
 let optArrayOfNullableToOptArrayOfOpt: option<array<Js.Nullable.t<'a>>> => option<
   array<option<'a>>,
@@ -589,14 +593,24 @@ module Store = {
 module RequiredFieldLogger = {
   type kind = [#"missing_field.log" | #"missing_field.throw"]
 
-  type arg = {"kind": kind, "owner": string, "fieldPath": string}
+  type arg = {"kind": string, "owner": string, "fieldPath": string}
 
   type js = arg => unit
 
   type t = (~kind: kind, ~owner: string, ~fieldPath: string) => unit
 
-  let toJs: t => js = f => arg =>
-    f(~kind=arg["kind"], ~owner=arg["owner"], ~fieldPath=arg["fieldPath"])
+  let toJs: t => js = f => arg => {
+    let kind = switch arg["kind"] {
+    | "missing_required_field.log" => Some(#"missing_field.log")
+    | "missing_required_field.throw" => Some(#"missing_field.throw")
+    | _ => None
+    }
+
+    switch kind {
+    | Some(kind) => f(~kind, ~owner=arg["owner"], ~fieldPath=arg["fieldPath"])
+    | None => ()
+    }
+  }
 }
 
 module Environment = {
@@ -612,7 +626,7 @@ module Environment = {
     treatMissingFieldsAsNull: bool,
     missingFieldHandlers: array<MissingFieldHandler.t>,
     @optional
-    requiredFieldLogger: RequiredFieldLogger.js,
+    relayFieldLogger: RequiredFieldLogger.js,
     @optional
     isServer: bool,
   }
@@ -640,7 +654,7 @@ module Environment = {
         | Some(handlers) => handlers->Belt.Array.concat([nodeInterfaceMissingFieldHandler])
         | None => [nodeInterfaceMissingFieldHandler]
         },
-        ~requiredFieldLogger=?requiredFieldLogger->Belt.Option.map(RequiredFieldLogger.toJs),
+        ~relayFieldLogger=?requiredFieldLogger->Belt.Option.map(RequiredFieldLogger.toJs),
         ~isServer?,
         (),
       ),

--- a/packages/rescript-relay/src/RescriptRelay.resi
+++ b/packages/rescript-relay/src/RescriptRelay.resi
@@ -30,6 +30,9 @@ type subscriptionNode<'node>
 /**This type shows all of the fragments that has been spread on this particular object.*/
 type fragmentRefs<'fragments>
 
+/**Internal fragment refs shape used by Relay Resolver schema assets.*/
+type resolverFragmentRefs<'fragments> = fragmentRefs<'fragments>
+
 /**The type of the id Relay uses to identify records in its store.*/
 type dataId
 
@@ -122,6 +125,9 @@ external storeRootType: string = "ROOT_TYPE"
 /**Internal, do not use.*/
 @module("./utils")
 external convertObj: ('a, Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>>, 'b, 'c) => 'd = "traverser"
+
+/**Internal, do not use.*/
+let resolverDataInjector: 'resolverDataInjector
 
 /**Read the following section on working with the Relay store: https://relay.dev/docs/en/relay-store*/
 module RecordProxy: {
@@ -844,6 +850,16 @@ type fetchQueryOptions = {
   networkCacheConfig?: cacheConfig,
   fetchPolicy?: fetchPolicy,
 }
+
+type loadQueryConfig = {
+  fetchKey: option<string>,
+  fetchPolicy: option<fetchPolicy>,
+  networkCacheConfig: option<cacheConfig>,
+}
+
+@module("react-relay")
+external loadQuery: (Environment.t, queryNode<'a>, 'variables, loadQueryConfig) => 'queryResponse =
+  "loadQuery"
 
 module type MakeLoadQueryConfig = {
   type variables

--- a/packages/rescript-relay/src/RescriptRelay_Fragment.res
+++ b/packages/rescript-relay/src/RescriptRelay_Fragment.res
@@ -78,19 +78,6 @@ type paginationFragmentReturnRaw<'fragment, 'refetchVariables> = {
   isLoadingPrevious: bool,
   refetch: ('refetchVariables, refetchableFnOpts) => Disposable.t,
 }
-type paginationBlockingFragmentReturn<'fragment, 'refetchVariables> = {
-  data: 'fragment,
-  loadNext: paginationLoadMoreFn,
-  loadPrevious: paginationLoadMoreFn,
-  hasNext: bool,
-  hasPrevious: bool,
-  refetch: (
-    ~variables: 'refetchVariables,
-    ~fetchPolicy: fetchPolicy=?,
-    ~onComplete: option<Js.Exn.t> => unit=?,
-    unit,
-  ) => Disposable.t,
-}
 type paginationFragmentReturn<'fragment, 'refetchVariables> = {
   data: 'fragment,
   loadNext: paginationLoadMoreFn,
@@ -114,9 +101,7 @@ external usePaginationFragment_: (
 ) => paginationFragmentReturnRaw<'fragment, 'refetchVariables> = "usePaginationFragment"
 
 /** React hook for paginating a fragment. Paginating with \
-                       this hook will _not_ cause your component to suspend. \
-                       If you want pagination to trigger suspense, look into \
-                       using `Fragment.useBlockingPagination`.*/
+                       this hook will _not_ cause your component to suspend.*/
 let usePaginationFragment = (
   ~node,
   ~fRef,
@@ -143,50 +128,6 @@ let usePaginationFragment = (
     hasPrevious: p.hasPrevious,
     isLoadingNext: p.isLoadingNext,
     isLoadingPrevious: p.isLoadingPrevious,
-    refetch: React.useMemo1(() => (~variables, ~fetchPolicy=?, ~onComplete=?, ()) => {
-      p.refetch(
-        RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw(
-          variables->convertRefetchVariables,
-        ),
-        internal_makeRefetchableFnOpts(~onComplete?, ~fetchPolicy?, ()),
-      )
-    }, [p.refetch]),
-  }
-}
-
-@module("react-relay/lib/relay-hooks/useBlockingPaginationFragment")
-external useBlockingPaginationFragment_: (
-  fragmentNode<'node>,
-  'fragmentRef,
-) => paginationFragmentReturnRaw<'fragment, 'refetchVariables> = "default"
-
-/** Like `Fragment.usePagination`, but calling the \
-                       pagination function will trigger suspense. Useful for \
-                       all-at-once pagination.*/
-let useBlockingPaginationFragment = (
-  ~node,
-  ~fRef,
-  ~convertFragment: 'fragment => 'fragment,
-  ~convertRefetchVariables: 'refetchVariables => 'refetchVariables,
-) => {
-  let p = useBlockingPaginationFragment_(node, fRef)
-  let data = RescriptRelay_Internal.internal_useConvertedValue(convertFragment, p.data)
-  {
-    data,
-    loadNext: React.useMemo1(() => (~count, ~onComplete=?, ()) => {
-      p.loadNext(
-        count,
-        {onComplete: ?onComplete->RescriptRelay_Internal.internal_nullableToOptionalExnHandler},
-      )
-    }, [p.loadNext]),
-    loadPrevious: React.useMemo1(() => (~count, ~onComplete=?, ()) => {
-      p.loadPrevious(
-        count,
-        {onComplete: ?onComplete->RescriptRelay_Internal.internal_nullableToOptionalExnHandler},
-      )
-    }, [p.loadPrevious]),
-    hasNext: p.hasNext,
-    hasPrevious: p.hasPrevious,
     refetch: React.useMemo1(() => (~variables, ~fetchPolicy=?, ~onComplete=?, ()) => {
       p.refetch(
         RescriptRelay_Internal.internal_cleanObjectFromUndefinedRaw(

--- a/packages/rescript-relay/src/RescriptRelay_Fragment.resi
+++ b/packages/rescript-relay/src/RescriptRelay_Fragment.resi
@@ -26,20 +26,6 @@ type paginationLoadMoreFn = (
   unit,
 ) => Disposable.t
 
-type paginationBlockingFragmentReturn<'fragment, 'refetchVariables> = {
-  data: 'fragment,
-  loadNext: paginationLoadMoreFn,
-  loadPrevious: paginationLoadMoreFn,
-  hasNext: bool,
-  hasPrevious: bool,
-  refetch: (
-    ~variables: 'refetchVariables,
-    ~fetchPolicy: fetchPolicy=?,
-    ~onComplete: option<Js.Exn.t> => unit=?,
-    unit,
-  ) => Disposable.t,
-}
-
 type paginationFragmentReturn<'fragment, 'refetchVariables> = {
   data: 'fragment,
   loadNext: paginationLoadMoreFn,
@@ -62,13 +48,6 @@ let usePaginationFragment: (
   ~convertFragment: 'fragment => 'fragment,
   ~convertRefetchVariables: 'refetchVariables => 'refetchVariables,
 ) => paginationFragmentReturn<'fragment, 'refetchVariables>
-
-let useBlockingPaginationFragment: (
-  ~node: fragmentNode<'a>,
-  ~fRef: 'b,
-  ~convertFragment: 'fragment => 'fragment,
-  ~convertRefetchVariables: 'refetchVariables => 'refetchVariables,
-) => paginationBlockingFragmentReturn<'fragment, 'refetchVariables>
 
 let useRefetchableFragment: (
   ~node: fragmentNode<'a>,

--- a/packages/rescript-relay/src/RescriptRelay_Internal.res
+++ b/packages/rescript-relay/src/RescriptRelay_Internal.res
@@ -34,4 +34,8 @@ let internal_nullableToOptionalExnHandler = x =>
   | Some(handler) => Some(maybeExn => maybeExn->Js.Nullable.toOption->handler)
   }
 
+external wrapUnion: 'value => 'wrapped = "%identity"
+external unwrapUnionValue: 'value => 'unwrapped = "%identity"
+let unwrapUnion = (value, _memberTypes) => value->unwrapUnionValue
+
 @live @unboxed type rec arg = Arg(_): arg

--- a/packages/rescript-relay/src/RescriptRelay_Internal.resi
+++ b/packages/rescript-relay/src/RescriptRelay_Internal.resi
@@ -4,4 +4,6 @@ let internal_removeUndefinedAndConvertNullsRaw: 't => 't
 let internal_nullableToOptionalExnHandler: option<option<'b> => 'a> => option<
   Js.Nullable.t<'b> => 'a,
 >
+let wrapUnion: 'value => 'wrapped
+let unwrapUnion: ('value, array<string>) => 'unwrapped
 @live @unboxed type rec arg = Arg(_): arg

--- a/packages/rescript-relay/src/utils.js
+++ b/packages/rescript-relay/src/utils.js
@@ -71,10 +71,16 @@ function traverse(
     var path = getPathName(thisPath);
 
     var instructions = instructionMap[path] || {};
+    var renameKey = instructions["k"];
+
+    if (typeof renameKey === "string" && renameKey !== key) {
+      newObj = getNewObj(newObj, currentObj);
+      newObj[renameKey] = currentObj[key];
+    }
 
     if (currentObj[key] == null) {
       newObj = getNewObj(newObj, currentObj);
-      newObj[key] = nullableValue;
+      newObj[renameKey || key] = nullableValue;
       continue;
     }
 


### PR DESCRIPTION
## What changed

- Points `packages/relay` at the Relay 21 upgrade branch/commit from `zth/relay#38`.
- Updates ReScript Relay runtime bindings for Relay 21, including `relayFieldLogger` and resolver data injection.
- Removes legacy `useBlockingPaginationFragment` support from the runtime and PPX template.
- Updates tests and generated fixtures for Relay 21 behavior, including required `@alias` handling and refetch variable retention.
- Keeps generated enums/unions as nominal ReScript variants, not polymorphic variants.

## Why

Relay 21 changed compiler output and runtime metadata shape. This PR adapts ReScript Relay to those changes while preserving the long-standing ReScript variant API.

## Validation

Passed locally:

- `cargo check -p common -p relay-typegen -p relay-compiler -p relay`
- `cargo test -p extract-graphql` (17 tests)
- `yarn build:test`
- `yarn build`
- `yarn test:ci` (23 suites, 59 tests)

Related compiler/submodule PR: https://github.com/zth/relay/pull/38