### PR TITLE
make fragments' `Test.fromData` be generated by relay compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+- generate fragments' `Test.fromData` inside `[FragmentName]_graphql.res` to avoid exporting the fragment module from the relay component. https://github.com/zth/rescript-relay/pull/635
+
 # 4.5.1
 
 - Fix `traverse` exiting after a custom-scalar field (single array-backed `c`, or `ca`), leaving subsequent fields on the same parent uncoerced. Surfaced as raw `null` for nullable response fields, raw ReScript values for unserialized variables, and (in nested input objects) silently skipped converters. Closes #582; extends #434's #407 fix so trailing fields are preserved.

--- a/packages/rescript-relay/__tests__/Test_testingHelpers.res
+++ b/packages/rescript-relay/__tests__/Test_testingHelpers.res
@@ -94,11 +94,11 @@ module Interleaved = {
 
     <div>
       <Synthetic
-        user={Fragment.Test.fromData({
+        user={TestTestingHelpers_user_graphql.Test.fromData({
           __id: RescriptRelay.makeDataId("interleaved-synthetic-user"),
           firstName: "Interleaved Synthetic",
           onlineStatus: Some(Online),
-          fragmentRefs: SubFragment.Test.fromData({lastName: "User"}),
+          fragmentRefs: TestTestingHelpers_sub_user_graphql.Test.fromData({lastName: "User"}),
         })}
       />
       <Synthetic user=data.loggedInUser.fragmentRefs />
@@ -109,35 +109,36 @@ module Interleaved = {
 @live
 let synthetic = () =>
   <Synthetic
-    user={Fragment.Test.fromData({
+    user={TestTestingHelpers_user_graphql.Test.fromData({
       __id: RescriptRelay.makeDataId("synthetic-user-1"),
       firstName: "Synthetic",
       onlineStatus: Some(Online),
-      fragmentRefs: SubFragment.Test.fromData({lastName: "User"}),
+      fragmentRefs: TestTestingHelpers_sub_user_graphql.Test.fromData({lastName: "User"}),
     })}
   />
 
 @live
 let syntheticOpt = () =>
   <SyntheticOpt
-    user={Fragment.Test.fromData({
+    user={TestTestingHelpers_user_graphql.Test.fromData({
       __id: RescriptRelay.makeDataId("synthetic-user-2"),
       firstName: "Synthetic",
       onlineStatus: Some(Online),
-      fragmentRefs: SubFragment.Test.fromData({lastName: "User"}),
+      fragmentRefs: TestTestingHelpers_sub_user_graphql.Test.fromData({lastName: "User"}),
     })}
   />
 
 @live
 let syntheticPlural = () =>
   <SyntheticPlural
-    users={PluralFragment.Test.fromData([
+    users={TestTestingHelpers_plural_user_graphql.Test.fromData([
       {id: "synthetic-user-3", firstName: "Plural Synthetic", onlineStatus: Some(Online)},
     ])}
   />
 
 @live
-let syntheticEmptyPlural = () => <SyntheticPlural users={PluralFragment.Test.fromData([])} />
+let syntheticEmptyPlural = () =>
+  <SyntheticPlural users={TestTestingHelpers_plural_user_graphql.Test.fromData([])} />
 
 @live
 let environment = () => RescriptRelay_Test.createMockEnvironment()

--- a/packages/rescript-relay/__tests__/__generated__/GroupAvatar_group_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/GroupAvatar_group_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #GroupAvatar_group]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #GroupAvatar_group]> =>
+    RescriptRelay_TestFragmentRef.make("GroupAvatar_group", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/HasNameComponent_hasName_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/HasNameComponent_hasName_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #HasNameComponent_hasName]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #HasNameComponent_hasName]> =>
+    RescriptRelay_TestFragmentRef.make("HasNameComponent_hasName", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/LocalUser____relay_model_instance_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/LocalUser____relay_model_instance_graphql.res
@@ -29,6 +29,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #LocalUser____relay_model_instance]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #LocalUser____relay_model_instance]> =>
+    RescriptRelay_TestFragmentRef.make("LocalUser____relay_model_instance", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/LocalUser__id_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/LocalUser__id_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #LocalUser__id]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #LocalUser__id]> =>
+    RescriptRelay_TestFragmentRef.make("LocalUser__id", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/RichContent_content_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RichContent_content_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #RichContent_content]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #RichContent_content]> =>
+    RescriptRelay_TestFragmentRef.make("RichContent_content", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestAliasedFragments_userFirstName_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestAliasedFragments_userFirstName_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_userFirstName]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_userFirstName]> =>
+    RescriptRelay_TestFragmentRef.make("TestAliasedFragments_userFirstName", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestAliasedFragments_userLastName_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestAliasedFragments_userLastName_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_userLastName]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_userLastName]> =>
+    RescriptRelay_TestFragmentRef.make("TestAliasedFragments_userLastName", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestCatchUnionMember_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestCatchUnionMember_member_graphql.res
@@ -51,6 +51,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestCatchUnionMember_member]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestCatchUnionMember_member]> =>
+    RescriptRelay_TestFragmentRef.make("TestCatchUnionMember_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestCatchUser_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestCatchUser_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestCatchUser_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestCatchUser_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestCatchUser_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestCompileInterfacesFragment_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestCompileInterfacesFragment_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestCompileInterfacesFragment_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestCompileInterfacesFragment_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestCompileInterfacesFragment_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections2_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections2_user_graphql.res
@@ -54,6 +54,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnections2_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnections2_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnections2_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnections2_user_member_friendsConnection"

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections3_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections3_user_graphql.res
@@ -43,6 +43,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnections3_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnections3_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnections3_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnectionsTest_user_user_friendsConnection"

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections_user_graphql.res
@@ -41,6 +41,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnections_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnections_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnections_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnections_user_friendsConnection"

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredPlural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredPlural_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragmentRequiredPlural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestFragmentRequiredPlural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestFragmentRequiredPlural_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequired_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequired_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragmentRequired_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragmentRequired_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragmentRequired_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_allowUnsafeEnum_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_allowUnsafeEnum_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_allowUnsafeEnum]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_allowUnsafeEnum]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_allowUnsafeEnum", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_plural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_plural_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragment_plural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestFragment_plural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_plural_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_sub_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_sub_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_sub_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_sub_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_sub_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayload_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayload_user_graphql.res
@@ -86,6 +86,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestLocalPayload_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestLocalPayload_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestLocalPayload_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationProvidedVariable_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationProvidedVariable_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestMutationProvidedVariable_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestMutationProvidedVariable_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestMutationProvidedVariable_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestMutation_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutation_user_graphql.res
@@ -54,6 +54,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestMutation_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestMutation_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestMutation_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestNodeInterface_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNodeInterface_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestNodeInterface_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestNodeInterface_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestNodeInterface_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestNonReact_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNonReact_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestNonReact_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestNonReact_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestNonReact_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
@@ -42,6 +42,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationInNode_query", data)
+}
+
 @live
 @inline
 let connectionKey = "TestPaginationInNode_friendsConnection"

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_user_graphql.res
@@ -36,6 +36,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationInNode_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
@@ -69,6 +69,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationUnion_query", data)
+}
+
 @live
 @inline
 let connectionKey = "TestPaginationUnion_query_members"

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_user_graphql.res
@@ -35,6 +35,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationUnion_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestPrefetchablePagination_user__edges_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPrefetchablePagination_user__edges_graphql.res
@@ -37,6 +37,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestPrefetchablePagination_user__edges]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestPrefetchablePagination_user__edges]>> =>
+    RescriptRelay_TestFragmentRef.make("TestPrefetchablePagination_user__edges", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestPrefetchablePagination_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPrefetchablePagination_user_graphql.res
@@ -43,6 +43,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPrefetchablePagination_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPrefetchablePagination_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPrefetchablePagination_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestProvidedVariables_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestProvidedVariables_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestProvidedVariables_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestProvidedVariables_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestProvidedVariables_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
@@ -37,6 +37,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingInNode_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetchingInNode_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetchingInNode_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingNoArgs_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingNoArgs_query_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingNoArgs_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetchingNoArgs_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetchingNoArgs_query", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingRecordNoArgs_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingRecordNoArgs_query_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingRecordNoArgs_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetchingRecordNoArgs_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetchingRecordNoArgs_query", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingRecord_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingRecord_user_graphql.res
@@ -41,6 +41,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingRecord_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetchingRecord_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetchingRecord_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
@@ -41,6 +41,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetching_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetching_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetching_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRelayResolvers_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRelayResolvers_user_graphql.res
@@ -33,6 +33,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayResolvers_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRelayResolvers_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestRelayResolvers_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRelayUserResolver2_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRelayUserResolver2_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayUserResolver2]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRelayUserResolver2]> =>
+    RescriptRelay_TestFragmentRef.make("TestRelayUserResolver2", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestRelayUserResolver_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRelayUserResolver_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayUserResolver]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRelayUserResolver]> =>
+    RescriptRelay_TestFragmentRef.make("TestRelayUserResolver", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscriptionProvidedVariable_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscriptionProvidedVariable_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestSubscriptionProvidedVariable_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestSubscriptionProvidedVariable_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestSubscriptionProvidedVariable_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscription_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscription_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestSubscription_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestSubscription_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestSubscription_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_plural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_plural_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_plural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_plural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestTestingHelpers_plural_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_sub_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_sub_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_sub_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_sub_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestTestingHelpers_sub_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestTestingHelpers_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestTestingHelpers_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestTestingHelpers_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentUser_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentUser_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUnionFragmentUser_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestUnionFragmentUser_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestUnionFragmentUser_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_member_graphql.res
@@ -49,6 +49,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUnionFragment_member]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestUnionFragment_member]> =>
+    RescriptRelay_TestFragmentRef.make("TestUnionFragment_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.res
@@ -50,6 +50,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestUnionFragment_plural_member]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestUnionFragment_plural_member]>> =>
+    RescriptRelay_TestFragmentRef.make("TestUnionFragment_plural_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/TestUpdatableFragments_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUpdatableFragments_query_graphql.res
@@ -40,6 +40,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUpdatableFragments_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestUpdatableFragments_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestUpdatableFragments_query", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/UserAvatar_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/UserAvatar_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserAvatar_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserAvatar_user]> =>
+    RescriptRelay_TestFragmentRef.make("UserAvatar_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/UserMeta____relay_model_instance_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/UserMeta____relay_model_instance_graphql.res
@@ -29,6 +29,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserMeta____relay_model_instance]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserMeta____relay_model_instance]> =>
+    RescriptRelay_TestFragmentRef.make("UserMeta____relay_model_instance", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests__/__generated__/UserName_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/UserName_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserName_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserName_user]> =>
+    RescriptRelay_TestFragmentRef.make("UserName_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/__tests_preloaded__/__generated__/TestPreloadedQueryProvidedVariables_user_graphql.res
+++ b/packages/rescript-relay/__tests_preloaded__/__generated__/TestPreloadedQueryProvidedVariables_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPreloadedQueryProvidedVariables_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPreloadedQueryProvidedVariables_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPreloadedQueryProvidedVariables_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
@@ -28,11 +28,8 @@ let make ~loc ~moduleName ~refetchableQueryName
               [
                 [%stri
                   module Test = struct
-                    let fromData
-                        (data :
-                          [%t typeFromGeneratedModule ["Types"; "fragment"]]) =
-                      RescriptRelay_TestFragmentRef.make
-                        [%e makeStringExpr ~loc moduleName] data
+                    let fromData =
+                      [%e valFromGeneratedModule ["Test"; "fromData"]]
                   end];
               ]
             | true -> []);


### PR DESCRIPTION
This allows to not export the `Fragment` from a relay component to keep fast refresh.
This implementation also makes it typesafe.

to be used with https://github.com/zth/relay/pull/39